### PR TITLE
[CHORE] 로컬 실행 환경 구성과 명세·컨벤션 문서 정비

### DIFF
--- a/.claude/skills/spring-architecture/SKILL.md
+++ b/.claude/skills/spring-architecture/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: spring-architecture
+description: 새 도메인/패키지를 만들거나 파일을 어디에 둘지 정할 때 사용. 도메인형 패키지 구조, 디렉터리 배치 규칙, 클래스 내 선언 순서(public → private), 네이밍 규칙을 다룬다. "새 도메인 추가", "패키지 어디에", "구조 잡아줘" 같은 요청에 해당.
+---
+
+# 아키텍처 & 패키지 구조
+
+## 기술 스택 전제
+
+- **언어**: Java 21
+- **프레임워크**: Spring Boot 3.5.7, Spring Data JPA
+- **DB**: MySQL (테스트는 H2)
+- **테스트**: JUnit 5, Mockito, RestAssured
+- **빌드**: Gradle
+
+## 도메인형 패키지 구조
+
+루트 패키지는 `com.dearjolly.server`. 그 아래 `domain`과 `global`로 나뉜다.
+
+```
+com.dearjolly.server/
+├── domain/
+│   ├── user/
+│   │   ├── controller/
+│   │   ├── service/
+│   │   ├── repository/
+│   │   ├── entity/
+│   │   ├── enums/
+│   │   ├── constants/        # 검증 상수 등 (필요 시)
+│   │   └── dto/
+│   │       ├── request/
+│   │       └── response/
+│   ├── letter/
+│   ├── feedback/
+│   └── skeleton/
+└── global/
+    └── exception/
+        ├── controller/
+        ├── exception/
+        ├── handler/
+        └── response/
+```
+
+### 배치 규칙
+
+- 새 기능은 **먼저 어느 도메인에 속하는지** 정하고, 그 도메인 하위에 계층 패키지를 만든다.
+- 계층 패키지는 필요한 것만 만든다. (조회 API가 없으면 `repository`를 미리 만들지 않는다)
+- DTO는 반드시 도메인 내부 `dto` 아래 `request` / `response`로 나눈다. 공용 DTO를 만들지 말 것.
+- 여러 도메인이 공유하는 것(예외, 설정, 공통 응답)만 `global`에 둔다.
+- 매직 넘버/정규식 등 검증 상수는 도메인의 `constants` 패키지에 `final` 클래스로 모은다.
+
+```java
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class UserValidationConstants {
+
+    public static final int NICKNAME_MIN_LENGTH = 2;
+    public static final int NICKNAME_MAX_LENGTH = 10;
+    public static final String NICKNAME_REGEX = "^[a-zA-Z0-9]+$";
+}
+```
+
+## 선언 순서
+
+- **메서드**: `public` → `private` 순서로 작성한다. (Entity는 별도 규칙 → `spring-entity` 스킬 참고)
+- **인터페이스 구현 클래스**: 인터페이스에 선언된 메서드 순서를 그대로 유지한다.
+- **필드**: 주입 대상(`private final`)을 클래스 최상단에 모은다.
+
+## 네이밍
+
+| 대상 | 규칙 | 예시 |
+|---|---|---|
+| 클래스명 | 파스칼 케이스 | `Users`, `SkeletonService` |
+| 변수/필드 | 카멜 케이스 | `socialId`, `createdAt` |
+| DB 테이블 (`@Table(name=)`) | 대문자 스네이크 케이스 | `USERS`, `LETTERS` |
+| DB 컬럼 (`@Column(name=)`) | 스네이크 케이스 | `social_id`, `created_at` |
+| 상수 | 대문자 스네이크 케이스 | `NICKNAME_MAX_LENGTH` |
+
+## 계층 간 의존 방향
+
+`Controller → Service → Repository → Entity` 한 방향으로만 흐른다.
+
+- Controller는 Repository를 직접 호출하지 않는다.
+- Entity를 Controller 응답으로 그대로 반환하지 않는다. 항상 Response DTO로 변환한다.
+- Service 메서드의 반환 타입은 Response DTO이거나 도메인 객체이며, Controller에 노출되는 것은 DTO다.

--- a/.claude/skills/spring-code-review/SKILL.md
+++ b/.claude/skills/spring-code-review/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: spring-code-review
+description: 백엔드 코드를 리뷰하거나 PR을 점검할 때 사용. 리뷰 관점(컨벤션 준수, 가독성, 예외 처리, 테스트 커버리지, 설계·확장성, API/DB/보안), 리뷰 코멘트 작성 방식, 계층별 자가 점검 체크리스트를 다룬다. "리뷰해줘", "PR 확인", "이 코드 괜찮아?" 요청에 해당.
+---
+
+# 코드 리뷰 기준
+
+## 리뷰 관점
+
+1. **컨벤션 준수** — 계층별 스킬(`spring-controller`, `spring-service`, `spring-entity`, `spring-dto`, `spring-exception`, `spring-test`)의 규칙을 기준으로 본다.
+2. **가독성** — 네이밍, 메서드 길이, 중복, 불필요한 로직.
+3. **예외 처리** — 공통 예외 처리 체계(`ErrorCode` / `BusinessException`)를 벗어난 곳이 없는지.
+4. **테스트** — 누락된 테스트 케이스가 있으면 **어떤 종류의 테스트가 필요한지 구체적으로 제안**한다 (API 테스트 / Service 단위 테스트 / Repository 테스트).
+5. **설계** — 객체지향 원칙, 서비스·도메인 책임 분리, 확장성, 유지보수성.
+6. **API / DB / 보안** — 엔드포인트 설계, 인덱스·제약조건, 민감 정보 노출.
+
+## 코멘트 작성 방식
+
+- 각 리뷰 포인트마다 **문제점 → 대안 → 장단점** 순으로 논리적으로 제시하고, 필요하면 예시 코드를 덧붙인다.
+- 지적은 **해당 라인 범위**를 명시해서 남긴다.
+- 리뷰가 과도하면 피로감을 준다. **꼭 필요한 부분에 집중**하고 나머지는 간단한 요약으로 넘긴다.
+- 취향 차이는 지적하지 않는다. 컨벤션 문서에 근거가 있거나 실제 결함일 때만 지적한다.
+
+## 계층별 자가 점검 체크리스트
+
+### Controller
+- [ ] 어노테이션 순서: `@Tag` → `@RestController` → `@RequestMapping` → `@RequiredArgsConstructor`
+- [ ] `@Operation`, `@Parameter` 로 Swagger 문서화가 되어 있는가
+- [ ] Request Body에 `@Valid`가 붙어 있는가
+- [ ] `ResponseEntity.status(...).body(...)` Fluent API로 상태 코드를 명시했는가
+- [ ] 비즈니스 로직이 새어 들어오지 않았는가 / Entity를 직접 반환하지 않는가
+
+### Service
+- [ ] 어노테이션 순서: `@Service` → `@RequiredArgsConstructor` → `@Transactional(readOnly = true)`
+- [ ] **CUD 메서드에 `@Transactional`이 개별 적용되어 있는가** (가장 흔한 누락)
+- [ ] 예외를 `BusinessException` + `ErrorCode`로 던지는가
+- [ ] public → private 메서드 순서가 지켜졌는가
+
+### Entity
+- [ ] 어노테이션 순서와 메서드 배치 순서(PrePersist → 생성 → 연관관계 → 비즈니스 → 생성자 → 검증)를 지켰는가
+- [ ] `@Column`에 `nullable` / `unique`를 지정했는가
+- [ ] `String` 필드에 `length`를 지정했는가
+- [ ] 테이블은 대문자 스네이크, 컬럼은 스네이크 케이스인가
+- [ ] `@Setter`가 없는가 / 양방향 연관관계 편의 메서드가 한 쪽에만 있는가
+
+### DTO
+- [ ] `record`로 선언했는가
+- [ ] Request에 검증 어노테이션이 적용됐는가 / 매직 넘버 대신 상수를 쓰는가
+- [ ] Response에 `from()` 정적 팩토리가 있는가
+
+### 예외
+- [ ] 새 예외 코드를 `ErrorCode` Enum에 정의했는가 (기존 코드 재사용 여부 확인)
+- [ ] 도메인 그룹 주석 블록 안에 배치했는가
+
+### 테스트
+- [ ] 추가/수정된 API마다 통합 테스트가 있는가 (**필수**)
+- [ ] 상태 코드뿐 아니라 응답 값·DTO까지 검증하는가
+- [ ] 실패 케이스가 포함됐는가
+- [ ] 복잡한 비즈니스 로직 / 직접 작성한 쿼리에 해당 계층 테스트가 있는가

--- a/.claude/skills/spring-controller/SKILL.md
+++ b/.claude/skills/spring-controller/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: spring-controller
+description: REST API 엔드포인트(Controller)를 작성하거나 수정할 때 사용. 어노테이션 순서, Swagger 문서화(@Tag/@Operation/@Parameter), @Valid 적용, ResponseEntity Fluent API 반환 규칙을 다룬다. "API 추가", "엔드포인트 만들어줘", "컨트롤러" 요청에 해당.
+---
+
+# Controller 작성 규칙
+
+## 어노테이션 순서 (클래스 레벨)
+
+반드시 이 순서를 지킨다.
+
+```
+@Tag → @RestController → @RequestMapping → @RequiredArgsConstructor
+```
+
+## 필수 규칙
+
+- **클래스 레벨**
+  - `@Tag(name, description)`으로 Swagger API 그룹을 명시한다.
+  - `@RequestMapping`으로 기본 경로를 설정한다. 경로는 `/api/v1/{도메인}` 형태.
+  - 의존성은 `private final` 필드 + `@RequiredArgsConstructor` 생성자 주입. `@Autowired` 필드 주입 금지.
+- **메서드 레벨**
+  - `@Operation(summary = "...")`으로 각 API 기능을 한 줄 요약한다.
+  - HTTP 매핑은 `@GetMapping` / `@PostMapping` 등 축약형을 쓴다.
+- **파라미터**
+  - `@Parameter(description = "...")`로 설명을 추가한다. 필수 값이면 `required = true`.
+  - Request Body에는 반드시 `@Valid`를 붙인다.
+- **반환값**
+  - `ResponseEntity`의 Fluent API(`status().body()`)로 상태 코드와 데이터를 **명시적으로** 반환한다.
+  - `HttpStatus`는 static import 해서 `OK`, `CREATED`처럼 쓴다.
+  - 조회는 `OK`, 생성은 `CREATED`, 본문 없는 삭제/수정은 `NO_CONTENT`.
+- **금지**
+  - Controller에 비즈니스 로직을 두지 않는다. 요청 위임과 응답 변환만 한다.
+  - Repository를 직접 주입받지 않는다.
+  - Entity를 그대로 반환하지 않는다.
+
+## 예시
+
+```java
+@Tag(name = "스켈레톤", description = "스켈레톤 생성, 조회 API")
+@RestController
+@RequestMapping("/api/v1/skeleton")
+@RequiredArgsConstructor
+public class SkeletonController {
+
+    private final SkeletonService skeletonService;
+
+    @Operation(summary = "저장된 모든 스켈레톤 목록 조회")
+    @GetMapping
+    public ResponseEntity<SkeletonListResponse> getSkeletons(
+            @Parameter(description = "조회 기준 시각 (생략 시 현재)")
+            @RequestParam(required = false) LocalDateTime clientAt
+    ) {
+        return ResponseEntity
+                .status(OK)
+                .body(skeletonService.getSkeletons(clientAt));
+    }
+
+    @Operation(summary = "새로운 스켈레톤 생성")
+    @PostMapping
+    public ResponseEntity<SkeletonGetResponse> createSkeleton(
+            @Parameter(description = "스켈레톤 생성 요청 객체", required = true)
+            @Valid @RequestBody SkeletonCreateRequest request
+    ) {
+        return ResponseEntity
+                .status(CREATED)
+                .body(skeletonService.createSkeleton(request));
+    }
+}
+```
+
+## 연계
+
+- 요청/응답 DTO 작성 → `spring-dto` 스킬
+- 예외 응답 포맷 → `spring-exception` 스킬
+- API를 추가했다면 **통합 테스트는 필수** → `spring-test` 스킬

--- a/.claude/skills/spring-dto/SKILL.md
+++ b/.claude/skills/spring-dto/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: spring-dto
+description: Request/Response DTO를 만들거나 수정할 때 사용. record 사용, 검증 어노테이션 적용, toEntity()/from() 정적 팩토리 메서드 규칙, 검증 상수 처리 방법을 다룬다. "요청 DTO", "응답 DTO", "validation 추가" 요청에 해당.
+---
+
+# DTO 작성 규칙
+
+## 공통
+
+- DTO는 **반드시 `record`로 선언**한다. 클래스 + Lombok 조합을 쓰지 않는다.
+- 위치: `domain/{도메인}/dto/request/`, `domain/{도메인}/dto/response/`
+- 네이밍: `{도메인}{동작}Request`, `{도메인}{동작}Response` (예: `UserCreateRequest`, `UserGetResponse`)
+- 여러 도메인이 공유하는 DTO를 만들지 않는다. 도메인별로 각자 정의한다.
+
+## Request DTO
+
+- **Validation 어노테이션을 적용**한다. Controller에서 `@Valid`와 짝을 이룬다.
+- 메시지는 한국어로 사용자에게 보여줄 수 있는 문구로 작성한다.
+- 길이/정규식 같은 값은 매직 넘버로 두지 말고 도메인의 `constants` 클래스 상수를 static import 해서 쓴다.
+- 필요 시 `toEntity()` 인스턴스 메서드로 엔티티 변환을 제공한다.
+
+```java
+public record ProjectCreateRequest(
+        @NotBlank(message = "이메일 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Length(
+                min = NICKNAME_MIN_LENGTH,
+                max = NICKNAME_MAX_LENGTH,
+                message = "닉네임은 {min}자 이상 {max}자 이하여야 합니다.")
+        @Pattern(regexp = NICKNAME_REGEX, message = "올바른 닉네임 형식이 아닙니다.")
+        String nickname,
+
+        @NotBlank
+        String description
+) {
+    public Users toEntity() {
+        return Users.create("temp_social_id", "temp", email, nickname);
+    }
+}
+```
+
+### 자주 쓰는 검증 어노테이션
+
+| 어노테이션 | 용도 |
+|---|---|
+| `@NotBlank` | 문자열 필수 (공백 문자열도 거부) |
+| `@NotNull` | 객체/숫자 필수 |
+| `@Email` | 이메일 형식 |
+| `@Length(min, max)` / `@Size` | 길이 제한 |
+| `@Pattern(regexp)` | 정규식 |
+| `@Positive`, `@Min`, `@Max` | 숫자 범위 |
+
+## Response DTO
+
+- 엔티티 → DTO 변환은 **`from()` 정적 팩토리 메서드**로 제공한다.
+- 목록 응답은 `{도메인}ListResponse`로 감싸고, 내부에 `List<{도메인}SummaryResponse>`를 담는다.
+- 엔티티를 필드로 그대로 들고 있지 않는다. 필요한 값만 평면화해서 담는다.
+
+```java
+public record ProjectSummaryResponse(
+        long id,
+        String title,
+        String thumbnail
+) {
+    // 엔티티를 응답 DTO로 변환: from() 정적 팩토리 메서드
+    public static ProjectSummaryResponse from(Project project) {
+        return new ProjectSummaryResponse(
+                project.getId(),
+                project.getTitle(),
+                project.getThumbnail()
+        );
+    }
+}
+```
+
+```java
+public record ProjectListResponse(
+        List<ProjectSummaryResponse> projects
+) {
+    public static ProjectListResponse from(List<Project> projects) {
+        return new ProjectListResponse(
+                projects.stream()
+                        .map(ProjectSummaryResponse::from)
+                        .toList()
+        );
+    }
+}
+```
+
+## 연계
+
+- 검증 실패 응답 포맷 → `spring-exception` 스킬
+- `@Valid` 적용 위치 → `spring-controller` 스킬

--- a/.claude/skills/spring-entity/SKILL.md
+++ b/.claude/skills/spring-entity/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: spring-entity
+description: JPA 엔티티(도메인 클래스)를 만들거나 수정할 때 사용. 어노테이션 순서, 메서드 배치 순서, @Column의 nullable/unique/length 필수 지정, 테이블·컬럼 네이밍, 연관관계 편의 메서드 규칙을 다룬다. "엔티티 만들어줘", "테이블 추가", "연관관계 매핑" 요청에 해당.
+---
+
+# Entity (Domain) 작성 규칙
+
+## 어노테이션 순서 (클래스 레벨)
+
+```
+@Entity → @Table(name = "XXX") → @Getter → @NoArgsConstructor(access = AccessLevel.PROTECTED)
+```
+
+`@Setter`는 절대 사용하지 않는다. 상태 변경은 의미 있는 이름의 비즈니스 메서드로만 한다.
+
+## 메서드 배치 순서 (중요)
+
+아래 순서를 그대로 지키고, 구분 주석으로 섹션을 나눈다.
+
+1. `@PrePersist` / `@PreUpdate` 관련 (protected)
+2. 생성 메서드 (public static)
+3. 연관관계 편의 메서드 (public)
+4. 비즈니스 메서드 (public)
+5. 생성자 (private)
+6. 검증 메서드 (private)
+
+## 컬럼 규칙
+
+- `@Column`의 **`nullable` 옵션은 필수로 고려하여 지정**한다.
+- `unique` 제약이 필요한지 항상 검토하고, 필요하면 명시한다.
+- **`String`(varchar) 타입은 `length`를 필수로 지정**한다. DB 저장 공간 최적화 목적.
+- Enum 필드는 `@Enumerated(EnumType.STRING)` + `length` 지정. `ORDINAL` 금지.
+- PK는 `@Id @GeneratedValue(strategy = GenerationType.IDENTITY)`, 필드명은 `id`, 컬럼명은 `{테이블단수}_id`.
+
+## 네이밍
+
+- 클래스명: 파스칼 케이스 (`Users`)
+- 테이블명: 대문자 스네이크 케이스 (`@Table(name = "USERS")`)
+- 필드명: 카멜 케이스 (`socialId`)
+- 컬럼명: 스네이크 케이스 (`@Column(name = "social_id")`)
+
+## 연관관계
+
+- 양방향 연관관계일 경우 **연관관계 편의 메서드는 한 쪽에만** 배치한다 (보통 주인이 아닌 쪽/부모 쪽).
+- 컬렉션 필드는 선언과 동시에 초기화한다 (`= new ArrayList<>()`).
+- `@ManyToOne`은 기본적으로 `fetch = FetchType.LAZY`를 지정한다.
+
+## 예시
+
+```java
+@Entity
+@Table(name = "USERS")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Users {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "social_id", nullable = false, length = 30)
+    private String socialId;
+
+    @Column(name = "provider", nullable = false, length = 10)
+    private String provider;
+
+    @Column(name = "email", nullable = false, length = 50)
+    private String email;
+
+    @Column(name = "nickname", nullable = false, length = 15)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 10)
+    private Role role;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Letters> letters = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // ========= 생성 메서드 =========
+    public static Users createMember(String socialId, String provider, String email, String nickname) {
+        return new Users(socialId, provider, email, nickname, ROLE_USER);
+    }
+
+    public static Users createAdmin(String socialId, String provider, String email, String nickname) {
+        return new Users(socialId, provider, email, nickname, ROLE_ADMIN);
+    }
+
+    // ========= 연관 관계 메서드 =========
+    public void addLetter(Letters letter) {
+        this.letters.add(letter);
+    }
+
+    // ========= 비즈니스 메서드 =========
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    // ========= 생성자 =========
+    private Users(String socialId, String provider, String email, String nickname, Role role) {
+        validateEmail(email);
+        this.socialId = socialId;
+        this.provider = provider;
+        this.email = email;
+        this.nickname = nickname;
+        this.role = role;
+    }
+
+    // ========= 검증 메서드 =========
+    private void validateEmail(String email) {
+        if (email == null) {
+            throw new IllegalArgumentException("이메일은 필수입니다.");
+        }
+    }
+}
+```
+
+## 연계
+
+- Enum은 도메인의 `enums` 패키지에 둔다 → `spring-architecture` 스킬
+- 엔티티 ↔ DTO 변환 → `spring-dto` 스킬

--- a/.claude/skills/spring-exception/SKILL.md
+++ b/.claude/skills/spring-exception/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: spring-exception
+description: 예외를 던지거나 새 에러 코드가 필요할 때 사용. ErrorCode Enum 정의 규칙, BusinessException 사용법, ErrorResponse 통일 응답 포맷, GlobalExceptionHandler 확장 방법을 다룬다. "예외 처리", "에러 코드 추가", "404 응답", "validation 실패 응답" 요청에 해당.
+---
+
+# 예외 처리 규칙
+
+## 3원칙
+
+1. 모든 예외 코드는 `global`의 **`ErrorCode` Enum에 정의**해서 관리한다. 새 예외가 필요하면 이 Enum에 상수를 추가한다.
+2. 비즈니스 로직에서 예외 발생 시 **`BusinessException`에 `ErrorCode`를 담아 던진다**.
+3. 응답은 **`ErrorResponse`를 통해 통일된 JSON 포맷**으로 나간다.
+
+## 위치
+
+```
+global/exception/
+├── exception/BusinessException.java
+├── response/ErrorCode.java
+├── response/ErrorResponse.java
+├── handler/GlobalExceptionHandler.java
+└── controller/CustomErrorController.java
+```
+
+## ErrorCode 추가
+
+`(HttpStatus, 코드, 메시지)` 3요소를 갖는다. 코드는 `{도메인 앞글자}{HTTP 상태}` 규칙 (`U404`, `R409`, `G500`).
+도메인별 주석 블록으로 그룹을 나눠 두었으니, **새 상수는 해당 도메인 블록 안에 추가**한다.
+
+```java
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // global
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G500", "서버 내부에 문제가 발생했습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "G405", "허용되지 않는 메서드입니다."),
+
+    // resource
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "R404", "요청한 리소스가 존재하지 않습니다."),
+    RESOURCE_DUPLICATED(HttpStatus.CONFLICT, "R409", "중복해서 저장할 수 없습니다."),
+
+    // user
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U404", "존재하지 않는 사용자입니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "U400", "올바르지 않은 값 또는 형식입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}
+```
+
+**추가 전에 반드시 기존 상수를 먼저 확인**한다. 의미가 같은 코드가 이미 있으면 재사용한다.
+
+## 예외 던지기
+
+```java
+// 기본
+throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+
+// 상세 메시지 추가 (ErrorCode 메시지 뒤에 " : {detail}"로 붙는다)
+throw new BusinessException(ErrorCode.RESOURCE_DUPLICATED, "이미 사용 중인 닉네임입니다.");
+
+// Optional 조회 관용구
+Users user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+```
+
+- 던지는 위치는 **Service 계층**이 기본이다.
+- Entity 내부 검증 메서드에서는 `IllegalArgumentException`을 쓴다 (도메인 불변식 위반).
+- Controller에서 try-catch로 예외를 잡지 않는다. `GlobalExceptionHandler`가 처리한다.
+
+## 응답 포맷
+
+```json
+{
+  "status": 404,
+  "code": "U404",
+  "message": "존재하지 않는 사용자입니다."
+}
+```
+
+## GlobalExceptionHandler
+
+`@RestControllerAdvice`로 이미 아래를 처리하고 있다. 새 핸들러가 필요할 때만 추가한다.
+
+| 예외 | 처리 |
+|---|---|
+| `BusinessException` | 담긴 `ErrorCode` 그대로 응답 |
+| `MethodArgumentNotValidException` | `@Valid` 실패 → `INVALID_INPUT_VALUE` + 필드별 메시지 조합 |
+| `MethodArgumentTypeMismatchException` | 파라미터 타입 불일치 → `INVALID_INPUT_VALUE` |
+| `HttpMessageNotReadableException` | JSON 파싱 실패 → `INVALID_INPUT_VALUE` |
+| `RuntimeException` | 그 외 전부 → `INTERNAL_SERVER_ERROR` |
+
+핸들러 추가 시 규칙:
+- 반환 타입은 `ResponseEntity<ErrorResponse>`, 생성은 `ErrorResponse.toResponseEntity(...)`로 통일.
+- `log.error(...)`를 남긴다. 예상 가능한 예외는 메시지만, 예상 못한 예외는 스택 트레이스까지.
+- 더 구체적인 예외 핸들러가 위, 포괄적인 것(`RuntimeException`)이 아래에 오도록 배치한다.

--- a/.claude/skills/spring-service/SKILL.md
+++ b/.claude/skills/spring-service/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: spring-service
+description: 비즈니스 로직(Service 계층)을 작성하거나 수정할 때 사용. 어노테이션 순서, @Transactional(readOnly = true) 기본 적용과 CUD 메서드 개별 @Transactional 규칙, 예외 처리 위치를 다룬다. "서비스 로직", "비즈니스 로직 추가", "트랜잭션" 요청에 해당.
+---
+
+# Service 작성 규칙
+
+## 어노테이션 순서 (클래스 레벨)
+
+```
+@Service → @RequiredArgsConstructor → @Transactional(readOnly = true)
+```
+
+## 트랜잭션 규칙 (중요)
+
+- 클래스 레벨에 **`@Transactional(readOnly = true)`를 기본으로 적용**한다.
+- 데이터 변경(Create/Update/Delete)이 일어나는 메서드에만 **개별적으로 `@Transactional`을 추가**한다.
+- 조회 전용 메서드에는 아무것도 붙이지 않는다 (클래스 레벨 설정이 적용됨).
+- 변경 메서드에 `@Transactional`을 빠뜨리면 `readOnly = true`가 적용되어 쓰기가 실패하거나 무시된다. 반드시 확인할 것.
+
+## 필수 규칙
+
+- 의존성은 `private final` 필드 + `@RequiredArgsConstructor` 생성자 주입.
+- 비즈니스 예외는 이 계층에서 던진다. `throw new BusinessException(ErrorCode.XXX)` 형태.
+- 엔티티 → Response DTO 변환은 Response DTO의 `from()` 정적 팩토리로 위임한다.
+- 엔티티 생성은 Entity의 정적 생성 메서드(`create...`)를 쓴다. 서비스에서 `new`로 직접 만들지 않는다.
+- 변경 감지(dirty checking)를 활용한다. 조회 후 엔티티의 비즈니스 메서드를 호출하면 `save()` 재호출이 필요 없다.
+- public 메서드를 먼저, private 헬퍼 메서드를 뒤에 배치한다.
+
+## 예시
+
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SkeletonService {
+
+    private final SkeletonRepository skeletonRepository;
+
+    /**
+     * Skeleton 전체 조회
+     */
+    public SkeletonListResponse getSkeletons() {
+        // 조회 로직 (클래스 레벨 readOnly = true 적용됨)
+    }
+
+    /**
+     * Skeleton 생성
+     */
+    @Transactional
+    public SkeletonGetResponse createSkeleton(SkeletonCreateRequest request) {
+        if (skeletonRepository.existsByName(request.categoryName())) {
+            throw new BusinessException(ErrorCode.RESOURCE_DUPLICATED);
+        }
+
+        Skeleton skeleton = skeletonRepository.save(request.toEntity());
+        return SkeletonGetResponse.from(skeleton);
+    }
+}
+```
+
+## 조회 실패 처리 관용구
+
+```java
+Users user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+```
+
+## 연계
+
+- `ErrorCode` 추가/사용 → `spring-exception` 스킬
+- 복잡한 비즈니스 로직이라면 Repository를 목킹한 서비스 단위 테스트 작성 → `spring-test` 스킬

--- a/.claude/skills/spring-test/SKILL.md
+++ b/.claude/skills/spring-test/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: spring-test
+description: 테스트 코드를 작성할 때 사용. 계층별 테스트 전략(통합/서비스/레포지터리), 어떤 테스트를 언제 쓸지 판단 기준, RestAssured 통합 테스트·Mockito 단위 테스트·H2 레포지터리 테스트 작성 방법을 다룬다. API를 새로 추가했다면 반드시 이 스킬을 함께 적용한다.
+---
+
+# 테스트 작성 규칙
+
+## 계층별 테스트 전략
+
+| 테스트 유형 | 도구/방법 | 작성 기준 | 검증 내용 |
+|---|---|---|---|
+| 통합 테스트 | RestAssured (E2E) | **API 하나당 필수** | 상태 코드, 응답값, DTO |
+| 서비스 테스트 | Repository 목킹 (Mockito) | 복잡한 비즈니스 로직이 있을 때 | 비즈니스 로직 |
+| 레포지터리 테스트 | H2 DB | 복잡한 쿼리(JPQL 등)가 있을 때 | 쿼리 정확성 |
+
+판단 기준:
+- **API를 추가/수정했다면 통합 테스트는 예외 없이 작성한다.**
+- 단순 위임 수준의 로직이면 서비스 테스트·레포지터리 테스트는 생략한다.
+- 분기·검증·계산이 얽힌 로직, 직접 작성한 JPQL/QueryDSL 쿼리가 있으면 해당 계층 테스트를 추가한다.
+- 테스트 DB는 H2를 사용한다.
+
+## 공통 규칙
+
+- 클래스명: `{대상}ApiTest`, `{대상}ServiceTest`, `{대상}RepositoryTest`
+- 모든 테스트 메서드에 `@DisplayName`으로 한국어 설명을 붙인다.
+  - 통합 테스트: `"GET /projects : 프로젝트 목록 조회 API"` (메서드 + 경로 + 설명)
+  - 단위 테스트: `"프로젝트를 저장한다."` (평서형)
+- 본문은 `// given` / `// when` / `// then` 주석으로 구획을 나눈다.
+- 테스트 클래스/메서드에 `public` 제어자를 붙이지 않는다.
+- 성공 케이스만이 아니라 **실패 케이스(검증 실패, 존재하지 않는 리소스)도 함께 검증**한다.
+
+## 통합 테스트 (RestAssured)
+
+```java
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+class ProjectApiTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    ProjectRepository projectRepository;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("GET /projects : 프로젝트 목록 조회 API")
+    @Test
+    void findAllProjects() {
+        // given - 테스트 데이터 준비
+        // when - API 호출
+        // then - 응답 검증 (상태 코드, 응답값, DTO)
+    }
+}
+```
+
+- `@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)`로 테스트 간 격리를 보장한다.
+- 상태 코드만 확인하고 끝내지 않는다. **응답 본문 필드까지 검증**한다.
+- 실패 응답은 `ErrorResponse` 포맷(`status`, `code`, `message`)을 검증한다.
+
+## 서비스 단위 테스트 (Mockito)
+
+```java
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTest {
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @InjectMocks
+    private ProjectService projectService;
+
+    @DisplayName("프로젝트를 저장한다.")
+    @Test
+    void save() {
+        // given - Mock 설정
+        // when - 서비스 메서드 호출
+        // then - 비즈니스 로직 검증
+    }
+}
+```
+
+- 예외 검증은 `assertThatThrownBy(...).isInstanceOf(BusinessException.class)` 형태로 `ErrorCode`까지 확인한다.
+- `@SpringBootTest`를 쓰지 않는다. 순수 단위 테스트로 유지한다.
+
+## 레포지터리 테스트
+
+- `@DataJpaTest` + H2로 작성한다.
+- 직접 작성한 JPQL/네이티브 쿼리, 복잡한 조건 조회에만 작성한다. Spring Data가 생성해 주는 기본 메서드는 테스트하지 않는다.
+
+## 의존성 확인
+
+RestAssured / H2 테스트를 새로 작성한다면 `build.gradle`에 아래가 있는지 먼저 확인하고, 없으면 추가한다.
+
+```gradle
+testImplementation 'io.rest-assured:rest-assured'
+testRuntimeOnly 'com.h2database:h2'
+```

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.gradle
+.idea
+.vscode
+.claude
+build/
+bin/
+out/
+docs/
+logs/
+*.log
+.DS_Store
+.env
+run.sh
+README.md
+CLAUDE.md

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# 이 파일은 커밋된다. 실제 비밀값은 절대 넣지 말 것.
+# 복사해서 .env 를 만들고, CHANGE_ME 자리를 각자 값으로 채운다.
+#   cp .env.example .env
+
+# ===== 애플리케이션 =====
+APP_PORT=8080
+
+# ===== MySQL =====
+MYSQL_PORT=3306
+MYSQL_DATABASE=dearjolly
+MYSQL_USER=jolly
+MYSQL_PASSWORD=CHANGE_ME
+MYSQL_ROOT_PASSWORD=CHANGE_ME
+
+# ===== JPA =====
+# create | update | validate | none
+JPA_DDL_AUTO=create
+JPA_SHOW_SQL=true
+
+# ===== MinIO (우표 이미지 저장소) =====
+MINIO_API_PORT=9000
+MINIO_CONSOLE_PORT=9001
+MINIO_ROOT_USER=jollyadmin
+MINIO_ROOT_PASSWORD=CHANGE_ME
+MINIO_BUCKET=dear-jolly-stamps

--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,6 @@ out/
 ## Mac ##
 .DS_Store
 
-## Local Run Script ##
-/run.sh
+## Docker 환경변수 ##
+.env
+!.env.example

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ out/
 
 ## Mac ##
 .DS_Store
+
+## Local Run Script ##
+/run.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md
+
+Dear Jolly 백엔드 서버. Java 21 / Spring Boot 3.5.7 / Spring Data JPA / MySQL / Gradle.
+
+모든 코드 컨벤션은 `.claude/skills/` 하위 스킬로 분리되어 있다.
+**이 문서는 "언제 어떤 스킬을 쓸지"만 규정한다. 규칙 자체는 각 스킬 문서에 있다.**
+
+## 스킬 라우팅
+
+| 작업 상황 | 사용할 스킬 |
+|---|---|
+| 새 도메인/패키지 추가, 파일 배치 위치 결정, 선언 순서·네이밍 판단 | `spring-architecture` |
+| REST API 엔드포인트 작성·수정 | `spring-controller` |
+| 비즈니스 로직 작성·수정, 트랜잭션 처리 | `spring-service` |
+| JPA 엔티티 생성·수정, 컬럼/연관관계 매핑 | `spring-entity` |
+| Request/Response DTO 작성, 입력값 검증 추가 | `spring-dto` |
+| 예외 던지기, 새 에러 코드 추가, 에러 응답 포맷 | `spring-exception` |
+| 테스트 코드 작성 | `spring-test` |
+| 코드 리뷰, PR 점검, 컨벤션 준수 확인 | `spring-code-review` |
+
+## 적용 규칙
+
+- **작업 전에 해당 스킬을 먼저 읽는다.** 기억에 의존해 컨벤션을 추측하지 않는다.
+- **하나의 작업에 여러 스킬이 걸리면 모두 적용한다.** 예: API 하나를 추가하면
+  `spring-controller` + `spring-service` + `spring-dto` + `spring-test`를 함께 본다.
+- **API를 추가하거나 수정했다면 `spring-test`는 항상 함께 적용한다.** 통합 테스트는 API당 필수다.
+- 엔티티를 건드렸다면 `docs/ERD.md`, API를 건드렸다면 `docs/API명세.md`의 갱신이 필요한지 확인한다.
+
+## 프로젝트 참고 문서
+
+- `docs/API명세.md` — API 명세
+- `docs/기능명세.md` — 기능 명세
+- `docs/ERD.md` — 데이터베이스 ERD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# ===== 1단계: 빌드 =====
+FROM eclipse-temurin:21-jdk AS builder
+WORKDIR /workspace
+
+# 의존성 레이어 캐싱: 소스보다 먼저 빌드 스크립트만 복사
+COPY gradlew settings.gradle build.gradle ./
+COPY gradle gradle
+RUN chmod +x gradlew && ./gradlew --no-daemon dependencies || true
+
+COPY src src
+RUN ./gradlew --no-daemon clean bootJar -x test
+
+# ===== 2단계: 실행 =====
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+ENV TZ=Asia/Seoul \
+    JAVA_OPTS="-XX:MaxRAMPercentage=75 -Duser.timezone=Asia/Seoul"
+
+RUN useradd --system --create-home --shell /usr/sbin/nologin jolly
+COPY --from=builder /workspace/build/libs/*.jar app.jar
+RUN chown jolly:jolly app.jar
+USER jolly
+
+EXPOSE 8080
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
 # jolly_server
 
 Write to Jolly, feel jolly
+
+## 기술 스택
+
+| 구분 | 사용 기술 |
+| --- | --- |
+| 언어 · 런타임 | Java 21 (Eclipse Temurin) |
+| 프레임워크 | Spring Boot 3.5.7 (Web, Data JPA, Validation) |
+| 데이터베이스 | MySQL 8.4 (`utf8mb4` / `Asia/Seoul`) |
+| 오브젝트 스토리지 | MinIO (우표 이미지, S3 호환) |
+| 빌드 | Gradle 8.14.3 (Wrapper) |
+| 실행 환경 | Docker · Docker Compose |
+
+## 실행 방법
+
+| 명령 | 설명 |
+| --- | --- |
+| `./run.sh` | 앱 + MySQL + MinIO 기동 (이미지 재빌드 포함) |
+| `./run.sh logs` | 앱 로그 실시간 확인 |
+| `./run.sh ps` | 컨테이너 상태 확인 |
+| `./run.sh restart` | 앱 컨테이너만 재빌드 후 재기동 |
+| `./run.sh down` | 컨테이너 종료 (데이터 유지) |
+| `./run.sh clean` | 컨테이너 + 볼륨 삭제 (DB·이미지 데이터 초기화) |
+
+> 최초 실행 시 `.env.example` 이 `.env` 로 자동 복사된다. 포트·계정 정보는 `.env` 에서 수정한다.
+
+## 접속 정보
+
+| 대상 | 주소 | 계정 |
+| --- | --- | --- |
+| 애플리케이션 | http://localhost:8080 | - |
+| MySQL | localhost:3306 (`dearjolly`) | `MYSQL_USER` / `MYSQL_PASSWORD` |
+| MinIO API | http://localhost:9000 | `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` |
+| MinIO 콘솔 | http://localhost:9001 | `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` |
+
+## 문서
+
+| 문서 | 내용 |
+| --- | --- |
+| [docs/기능명세.md](docs/기능명세.md) | 기능 명세 |
+| [docs/API명세.md](docs/API명세.md) | API 명세 |
+| [docs/ERD.md](docs/ERD.md) | 데이터 모델 |

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,122 @@
+name: dear-jolly
+
+services:
+  # ===== MySQL =====
+  mysql:
+    image: mysql:8.4
+    container_name: dear-jolly-mysql
+    restart: unless-stopped
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_0900_ai_ci
+      - --default-time-zone=+09:00
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      TZ: Asia/Seoul
+    ports:
+      - "${MYSQL_PORT:-3306}:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+    networks:
+      - dear-jolly
+
+  # ===== MinIO (우표 이미지 오브젝트 스토리지) =====
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    container_name: dear-jolly-minio
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      TZ: Asia/Seoul
+    ports:
+      - "${MINIO_API_PORT:-9000}:9000"    # S3 API
+      - "${MINIO_CONSOLE_PORT:-9001}:9001" # 웹 콘솔
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+    networks:
+      - dear-jolly
+
+  # ===== MinIO 초기화 (버킷 생성 + 공개 읽기 권한) =====
+  minio-init:
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    container_name: dear-jolly-minio-init
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      MINIO_BUCKET: ${MINIO_BUCKET}
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD &&
+      mc mb --ignore-existing local/$$MINIO_BUCKET &&
+      mc anonymous set download local/$$MINIO_BUCKET &&
+      echo '[minio-init] 버킷 준비 완료: '$$MINIO_BUCKET
+      "
+    networks:
+      - dear-jolly
+
+  # ===== Spring Boot 애플리케이션 =====
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: dear-jolly-server:local
+    container_name: dear-jolly-app
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+    environment:
+      TZ: Asia/Seoul
+      SERVER_PORT: 8080
+      # --- DB ---
+      MYSQL_URL: jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      JPA_DDL_AUTO: ${JPA_DDL_AUTO:-create}
+      JPA_SHOW_SQL: ${JPA_SHOW_SQL:-true}
+      # --- MinIO ---
+      MINIO_ENDPOINT: http://minio:9000
+      MINIO_PUBLIC_ENDPOINT: http://localhost:${MINIO_API_PORT:-9000}
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD}
+      MINIO_BUCKET: ${MINIO_BUCKET}
+    ports:
+      - "${APP_PORT:-8080}:8080"
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/8080"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 40s
+    networks:
+      - dear-jolly
+
+volumes:
+  mysql-data:
+  minio-data:
+
+networks:
+  dear-jolly:
+    driver: bridge

--- a/docs/API명세.md
+++ b/docs/API명세.md
@@ -1,41 +1,71 @@
 # Dear Jolly — API 명세서 (MVP)
 
-> 도메인/기능 배경은 [기능명세.md](./기능명세.md) 참고. 이 문서는 **요청/응답 계약**만 다룬다.
-> letter 도메인 4개 API 는 팀 초안을 그대로 반영했고, user / version 도메인은 동일한 형식으로 확장한 **제안**이다.
+> 이 문서는 **요청/응답 계약의 정본**이다. 각 API 의 `도메인 규칙` 항목은 앱·서버가 함께 지켜야 하는 조건을 요약한 것이고, 전체 규칙과 처리 흐름은 [기능명세.md](./기능명세.md), 테이블·제약 조건은 [ERD.md](./ERD.md) 를 따른다.
 
 | 항목 | 내용 |
 | --- | --- |
-| 문서 버전 | v1.1 |
+| 최종 갱신 | 2026-08-22 |
 | Base URL | `https://{host}` |
 | 인증 | `Authorization: Bearer {accessToken}` |
 | Content-Type | `application/json; charset=UTF-8` |
-| 시간대 | `Asia/Seoul` (KST) |
 | 날짜 포맷 | `LocalDate` → `yyyy-MM-dd` / `LocalDateTime` → `yyyy-MM-dd'T'HH:mm:ss` |
 
 ---
 
 ## 1. 엔드포인트 목록
 
-| # | 도메인 | Method | 엔드포인트 | 설명 | 인증 | 상태 |
-| --- | --- | --- | --- | --- | :---: | --- |
-| 1 | user | `POST` | `/api/v1/auth/login` | 소셜 로그인 (회원가입 포함) | — | 임시 |
-| 2 | user | `POST` | `/api/v1/users/terms` | 약관 동의 | ✔ | 제안 |
-| 3 | user | `GET` | `/api/v1/users` | 계정 정보 조회 | ✔ | 제안 |
-| 4 | user | `DELETE` | `/api/v1/users` | 회원 탈퇴 | ✔ | 제안 |
-| 5 | user | `PATCH` | `/api/v1/users/nickname` | 닉네임 설정 | ✔ | 확정 |
-| 6 | letter | `POST` | `/api/v1/letter` | 단일 편지 작성 + 피드백 요청 | ✔ | **초안 확정** |
-| 7 | letter | `GET` | `/api/v1/letters/{letterId}` | 편지 및 피드백 상세 조회 | ✔ | **초안 확정** |
-| 8 | letter | `GET` | `/api/v1/letters` | 전체 편지 리스트 조회 | ✔ | **초안 확정** |
-| 9 | letter | `GET` | `/api/v1/home` | 닉네임, 모은 우표 수 조회 | ✔ | **초안 확정** |
-| 10 | version | `GET` | `/api/v1/version` | 최소 지원 버전 조회 | — | 제안 |
+| # | 패키지 | Method | 엔드포인트 | 설명 | 인증 | 온보딩 |
+| --- | --- | --- | --- | --- | :---: | :---: |
+| 1 | user | `POST` | `/api/v1/auth/login` | 소셜 로그인 (회원가입 포함) | — | — |
+| 2 | user | `POST` | `/api/v1/auth/reissue` | 토큰 재발급 | — | — |
+| 3 | user | `POST` | `/api/v1/auth/logout` | 로그아웃 | ✔ | — |
+| 4 | user | `POST` | `/api/v1/users/terms` | 약관 동의 · 마케팅 동의 철회 | ✔ | — |
+| 5 | user | `GET` | `/api/v1/users` | 계정 정보 조회 | ✔ | — |
+| 6 | user | `DELETE` | `/api/v1/users` | 회원 탈퇴 | ✔ | — |
+| 7 | user | `PATCH` | `/api/v1/users/nickname` | 닉네임 설정 | ✔ | — |
+| 8 | letter | `POST` | `/api/v1/letters` | 편지 작성 + 피드백 요청 | ✔ | ✔ |
+| 9 | letter | `GET` | `/api/v1/letters/{letterId}` | 편지 및 피드백 상세 조회 | ✔ | ✔ |
+| 10 | letter | `GET` | `/api/v1/letters` | 전체 편지 리스트 조회 | ✔ | ✔ |
+| 11 | letter | `GET` | `/api/v1/home` | 닉네임, 모은 우표 수 조회 | ✔ | ✔ |
+| 12 | global | `GET` | `/api/v1/version` | 최소 지원 버전 조회 | — | — |
 
-⚠️ 초안 검토 중 발견한 충돌 사항이 있다. 구현 전 [8. 확인 필요 항목](#8-확인-필요-항목) 을 먼저 확정할 것.
+- **패키지** 열은 서버 구현 위치다. `version` 은 도메인이 아니라 `global` 하위이며, `/api/v1/home` 은 편지 집계가 본질이므로 `letter` 도메인에 둔다 ([기능명세 §2.1](./기능명세.md#21-패키지-구조)).
+- **온보딩** 열이 ✔ 인 API 는 온보딩 미완료 시 `USER_005` 로 차단된다 (§2.6).
 
 ---
 
 ## 2. 공통 규약
 
-### 2.1 에러 응답 포맷
+### 2.1 인증
+
+| 항목 | 값 |
+| --- | --- |
+| 헤더 | `Authorization: Bearer {accessToken}` |
+| Access Token 만료 | 30분 |
+| Refresh Token 만료 | 14일 |
+| 인증 불필요 | `POST /api/v1/auth/login`, `POST /api/v1/auth/reissue`, `GET /api/v1/version` |
+
+- Refresh Token 은 재발급 시 **회전(rotate)** 되며, 서버에 저장된 값과 다르면 `AUTH_004` 로 거절한다.
+- 인증 필터는 토큰 서명·만료를 검증한 뒤 **계정 상태까지 확인**한다. 탈퇴 처리된 계정의 토큰은 `AUTH_007`(401) 로 거절한다. 탈퇴 직후 최대 30분간 유효한 Access Token 이 남아 있기 때문이다.
+
+### 2.2 성공 응답
+
+별도 래퍼 없이 DTO 를 그대로 반환한다.
+
+| 상황 | 상태 코드 |
+| --- | --- |
+| 조회 · 수정 성공 | `200 OK` |
+| 생성 성공 | `201 Created` |
+| 처리 성공, 본문 없음 | `204 No Content` |
+
+**예외 2건**
+
+| API | 코드 | 이유 |
+| --- | --- | --- |
+| `POST /api/v1/auth/login` | `200 OK` | 신규 가입을 함께 처리하지만 로그인/가입이 단일 엔드포인트이며, 앱은 `isNewUser` 로 구분한다. 같은 요청이 상황에 따라 200/201 을 오가지 않도록 200 으로 고정한다 |
+| `POST /api/v1/letters` (중복) | `200 OK` | 60초 내 동일 본문 재요청은 새 편지를 만들지 않고 최초 편지를 반환하므로 생성이 아니다 (§4.1) |
+
+### 2.3 에러 응답
 
 ```json
 {
@@ -46,19 +76,59 @@
 ```
 
 - [필수] `status` (Integer): HTTP 상태 코드
-- [필수] `code` (String): `{도메인}_{일련번호}` 형식
-- [필수] `message` (String): 에러 메시지
+- [필수] `code` (String): `{도메인}_{일련번호}` 형식 (`AUTH_`, `USER_`, `LETTER_`, `COMMON_`)
+- [필수] `message` (String): 사용자 노출 가능한 에러 메시지
 
-전체 코드 목록은 [7. 에러 코드](#7-에러-코드) 참고.
+**공통 핸들러가 생산하는 코드**
 
-### 2.2 인증
+아래 코드는 개별 엔드포인트에 매핑되지 않고 `GlobalExceptionHandler` · Security 계층에서 공통으로 발생한다. 각 API 의 실패 응답 표에는 다시 적지 않는다.
 
-| 항목 | 값 |
+| code | status | 발생 지점 |
+| --- | --- | --- |
+| `AUTH_005` | 401 | 토큰 누락 · 서명 위조 · 만료 (`AuthenticationEntryPoint`) |
+| `AUTH_006` | 403 | 인증은 됐으나 권한이 부족 (`AccessDeniedHandler`). MVP 에 관리자 API 가 없어 실제로는 발생하지 않는다 |
+| `AUTH_007` | 401 | 탈퇴 처리된 계정의 토큰 (인증 필터) |
+| `COMMON_001` | 400 | 요청 바디 파싱 실패, 타입 불일치, 쿼리 파라미터 제약 위반 |
+| `COMMON_002` | 404 | 존재하지 않는 경로 |
+| `COMMON_003` | 405 | 지원하지 않는 HTTP 메서드 |
+| `COMMON_004` | 429 | Rate limit 초과 ([기능명세 §4.2](./기능명세.md#42-성능--제한)) |
+| `COMMON_005` | 500 | 처리되지 않은 서버 오류 |
+
+전체 목록은 [7. 에러 코드](#7-에러-코드) 참고.
+
+### 2.4 시간 · 타임존
+
+| 값 | 기준 |
 | --- | --- |
-| 헤더 | `Authorization: Bearer {accessToken}` |
-| Access Token 만료 | 30분 |
-| Refresh Token 만료 | 14일 |
-| 인증 불필요 | `POST /api/v1/auth/login`, `GET /api/v1/version` |
+| 편지 작성 시각 (`writtenAt` + `timeZone`) | **클라이언트가 명시**한다 |
+| 편지 날짜 (`date`) | `writtenAt` 을 `timeZone` 기준으로 환산한 날짜 |
+| 서버 생성 시각 (`createdAt`) | 서버 저장 시각을 요청의 `timeZone` 기준으로 변환해 반환 |
+| 그 외 모든 서버 시각 | `Asia/Seoul` (KST) |
+
+편지 날짜에 KST 를 강제하지 않는다. 해외에서 작성한 편지는 현지 날짜로 기록된다.
+
+### 2.5 페이징
+
+| 파라미터 | 기본값 | 제약 |
+| --- | --- | --- |
+| `page` | 0 | 0 이상 |
+| `size` | 10 | 1 ~ 50 |
+| `sort` | `LATEST` | `LATEST` / `OLDEST` |
+
+제약을 벗어난 값은 `COMMON_001`(400) 이다.
+
+### 2.6 온보딩 가드
+
+온보딩(필수 약관 동의 + 닉네임 등록)을 마치지 않은 유저는 **본 기능 API 를 호출할 수 없다** (R11).
+
+| 항목 | 내용 |
+| --- | --- |
+| 판별 | `SERVICE` · `PRIVACY` 의 최신 동의 이력이 모두 `agreed = true` **그리고** 닉네임이 등록됨 |
+| 차단 대상 | §1 목록의 **온보딩** 열이 ✔ 인 API (`/api/v1/letters` 3종, `/api/v1/home`) |
+| 위반 시 | `USER_005` (400) |
+
+- 이 가드 덕분에 편지 목록·홈 응답의 `nickname` 은 **항상 non-null** 이다.
+- 정상 앱 플로우에서는 온보딩 화면을 건너뛸 수 없으므로 이 코드는 거의 나가지 않는다. 앱을 우회한 직접 호출에 대한 방어선이다.
 
 ---
 
@@ -69,6 +139,13 @@
 > **API 설명**
 > - 카카오 / 애플 소셜 로그인을 수행합니다.
 > - 가입되지 않은 유저라면 회원가입을 함께 처리합니다.
+>
+> **도메인 규칙**
+> - 유저는 `(provider, provider 회원 식별자)` 조합으로 식별한다. 같은 이메일이라도 카카오/애플은 별개 계정이다.
+> - 가입 직후에는 약관 동의 이력이 없고 닉네임이 `null` 이다. 앱은 응답의 온보딩 상태로 진입 화면을 결정한다.
+> - Refresh Token 은 **유저당 1개만 유지**한다(단일 세션). 새로 로그인하면 이전 토큰은 무효가 된다.
+> - **탈퇴한 계정으로 다시 로그인하면 항상 신규 가입**이다 (`isNewUser: true`). 이전 편지는 복원되지 않으며 온보딩을 처음부터 다시 거친다.
+> - 회원가입을 포함하지만 응답은 `201` 이 아니라 `200` 이다 (§2.2).
 
 #### Request
 
@@ -111,7 +188,7 @@
 - [필수] `refreshToken` (String): 리프레시 토큰
 - [필수] `userId` (Long): 유저 ID
 - [필수] `isNewUser` (Boolean): 이번 요청으로 가입된 유저인지 여부
-- [필수] `termsAgreed` (Boolean): 필수 약관 동의 완료 여부
+- [필수] `termsAgreed` (Boolean): 필수 약관(`SERVICE` · `PRIVACY`) 동의 완료 여부
 - [필수] `nicknameRegistered` (Boolean): 닉네임 등록 여부
 
 **앱 분기**
@@ -140,11 +217,121 @@
 
 ---
 
-### 3.2 `POST /api/v1/users/terms`
+### 3.2 `POST /api/v1/auth/reissue`
+
+> **API 설명**
+> - Refresh Token 으로 Access Token 을 재발급합니다.
+> - Refresh Token 도 함께 재발급(회전)되며, 이전 토큰은 즉시 무효화됩니다.
+>
+> **도메인 규칙**
+> - Access Token 만료는 30분, Refresh Token 만료는 14일이다.
+> - 전달받은 Refresh Token 이 **서버에 저장된 값과 문자열까지 일치**해야 한다. 불일치하면 탈취된 이전 토큰의 재사용으로 보고 거절한다.
+> - 만료된 Access Token 으로도 호출할 수 있도록 인증 필터에서 제외한다.
+> - 탈퇴 처리된 계정의 Refresh Token 은 탈퇴 시점에 `null` 이 되므로 `AUTH_004` 로 거절된다.
+
+#### Request
+
+**Endpoint**
+
+```
+/api/v1/auth/reissue
+```
+
+**Authorization 헤더**: 불필요 (만료된 Access Token 으로도 호출 가능)
+
+**Body**
+
+```json
+{
+    "refreshToken": "eyJhbGciOiJIUzI1NiJ9..."
+}
+```
+
+- [필수] `refreshToken` (String): 로그인 시 발급받은 리프레시 토큰
+
+#### `성공` Response 200
+
+```json
+{
+    "accessToken": "eyJhbGciOiJIUzI1NiJ9...",
+    "refreshToken": "eyJhbGciOiJIUzI1NiJ9..."
+}
+```
+
+- [필수] `accessToken` (String): 새 액세스 토큰
+- [필수] `refreshToken` (String): 새 리프레시 토큰 (앱은 기존 값을 이 값으로 교체 저장)
+
+#### `실패` Error Response
+
+```json
+{
+    "status": 401,
+    "code": "AUTH_004",
+    "message": "로그인이 만료되었습니다. 다시 로그인해주세요."
+}
+```
+
+| code | status | 상황 |
+| --- | --- | --- |
+| `AUTH_004` | 401 | Refresh Token 만료 · 위조 · 서버 저장값과 불일치 |
+
+- 앱은 `AUTH_004` 를 받으면 저장된 토큰을 폐기하고 로그인 화면으로 이동한다.
+
+---
+
+### 3.3 `POST /api/v1/auth/logout`
+
+> **API 설명**
+> - 서버에 저장된 Refresh Token 을 무효화합니다.
+> - 카카오 세션 종료 등 소셜 로그아웃은 앱 SDK 에서 처리합니다.
+>
+> **도메인 규칙**
+> - 로그아웃은 **세션만 끊는다.** 편지·계정 데이터는 그대로 보존된다 (디자인 문구: *"편지는 잘 보관해 둘게요. 언제든 다시 와요!"*).
+> - 계정과 데이터를 지우는 것은 회원 탈퇴(§3.6)뿐이다.
+> - 온보딩 미완료 상태에서도 호출할 수 있다.
+
+#### Request
+
+**Endpoint**
+
+```
+/api/v1/auth/logout
+```
+
+**Authorization 헤더**
+
+```
+Bearer eyJhbGciOiJIUzI1NiJ9...
+```
+
+**Body**: 없음
+
+#### `성공` Response 204
+
+```
+(No Content)
+```
+
+#### `실패` Error Response
+
+공통 인증 실패 코드(`AUTH_005` · `AUTH_007`)만 발생한다. §2.3 참고.
+
+---
+
+### 3.4 `POST /api/v1/users/terms`
 
 > **API 설명**
 > - 온보딩 약관 동의 내역을 저장합니다.
+> - 설정 화면에서 마케팅 동의를 철회할 때도 같은 API 를 사용합니다.
 > - 필수 약관(`SERVICE`, `PRIVACY`)에 모두 동의해야 통과합니다.
+>
+> **도메인 규칙**
+> - `MARKETING` 은 선택 항목이며, 동의하지 않아도 서비스 이용에 제한이 없다.
+> - 동의 내역은 **덮어쓰지 않고 이력으로 누적**한다. 요청에 담긴 항목마다 새 행이 쌓이며, 현재 상태는 항목별 최신 행이다 ([ERD §2.2](./ERD.md#22-terms_agreements--약관-동의-이력)).
+> - 동의 시각은 **서버 시각(KST)** 으로 기록한다. 동의 시점의 약관 버전도 함께 기록한다.
+> - **약관이 개정돼도 재동의를 요구하지 않는다.** 버전은 사후 입증용 기록이며 `termsAgreed` 판별에 쓰지 않는다.
+> - 요청 바디에 포함하지 않은 항목은 건드리지 않는다. 마케팅만 철회하려면 `MARKETING` 한 건만 보내면 된다.
+> - 약관 본문은 서버가 제공하지 않는다. 웹뷰 링크(§5.1)로 처리한다.
 
 #### Request
 
@@ -172,9 +359,19 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
 }
 ```
 
-- [필수] `agreements` (Array): 약관 동의 목록
+- [필수] `agreements` (Array): 약관 동의 목록 (1개 이상)
     - [필수] `type` (String): 약관 종류 (`SERVICE`, `PRIVACY`, `MARKETING`)
     - [필수] `agreed` (Boolean): 동의 여부
+
+**마케팅 철회 예시**
+
+```json
+{
+    "agreements": [
+        { "type": "MARKETING", "agreed": false }
+    ]
+}
+```
 
 #### `성공` Response 200
 
@@ -184,7 +381,7 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
 }
 ```
 
-- [필수] `termsAgreed` (Boolean): 필수 약관 동의 완료 여부
+- [필수] `termsAgreed` (Boolean): 이 요청 반영 후의 필수 약관 동의 완료 여부
 
 #### `실패` Error Response
 
@@ -196,12 +393,22 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
 }
 ```
 
+| code | status | 상황 |
+| --- | --- | --- |
+| `USER_002` | 400 | 이 요청 반영 후에도 `SERVICE` 또는 `PRIVACY` 가 미동의 상태 |
+| `USER_001` | 404 | 사용자를 찾을 수 없음 |
+
 ---
 
-### 3.3 `GET /api/v1/users`
+### 3.5 `GET /api/v1/users`
 
 > **API 설명**
 > - 설정 화면에 표시할 계정 정보를 조회합니다.
+>
+> **도메인 규칙**
+> - 이메일은 Apple private relay 거부 등으로 제공되지 않을 수 있다. 이 경우 `null` 이며 앱은 provider 명만 표시한다. **서버가 대체 주소를 지어내지 않는다.**
+> - 온보딩을 마치지 않은 유저는 `nickname` 이 `null` 이다. 이 API 는 온보딩 가드 대상이 아니므로 그 상태로도 호출된다.
+> - `marketingAgreed` 는 `MARKETING` 의 **최신 동의 이력**의 값이다. 이력이 없으면 `false` 다.
 
 #### Request
 
@@ -224,16 +431,14 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
     "nickname": "ilovesally",
     "provider": "KAKAO",
     "email": "kakao_user@email.com",
-    "marketingAgreed": true,
-    "appVersion": "1.0.0"
+    "marketingAgreed": true
 }
 ```
 
-- [필수] `nickname` (String): 유저 닉네임
+- [선택] `nickname` (String): 유저 닉네임 (**온보딩 전에는 `null`**)
 - [필수] `provider` (String): 로그인 수단 (`KAKAO`, `APPLE`) — 앱에서 아이콘 매핑
-- [선택] `email` (String): 소셜 계정 이메일 (Apple private relay 등 미제공 시 `null`)
+- [선택] `email` (String): 소셜 계정 이메일 (provider 미제공 시 `null`)
 - [필수] `marketingAgreed` (Boolean): 마케팅 수신 동의 여부
-- [선택] `appVersion` (String): 표시용 서비스 버전
 
 #### `실패` Error Response
 
@@ -247,11 +452,20 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
 
 ---
 
-### 3.4 `DELETE /api/v1/users`
+### 3.6 `DELETE /api/v1/users`
 
 > **API 설명**
 > - 회원 탈퇴를 처리합니다.
 > - 모든 편지와 계정 정보가 삭제되며 복구할 수 없습니다.
+>
+> **도메인 규칙**
+> - **사용자 관점에서 삭제는 되돌릴 수 없다.** 편지·피드백·교정 내역이 모두 사라진다 (디자인 문구: *"탈퇴하면 모든 편지와 계정 정보가 함께 삭제되며 다시 복구할 수 없어요."*).
+> - **서버는 즉시 접근을 차단한 뒤 30일간 데이터를 보존하고, 유예기간이 지나면 완전 삭제한다.** 오삭제 복구와 분쟁 대응을 위한 내부 보존이며, 사용자에게 노출되는 복구 수단은 없다. 이 사실은 개인정보처리방침의 보유기간 항목에 명시한다.
+> - 탈퇴 즉시 Refresh Token 이 무효화되고, 남아 있는 Access Token 도 `AUTH_007`(401) 로 거절된다.
+> - 탈퇴 후 같은 소셜 계정으로 다시 로그인하면 **신규 가입**으로 처리된다. 이전 편지는 복원되지 않는다.
+> - Apple 유저는 **토큰 revoke 가 필수**다. 누락 시 App Store 심사 리젝 사유가 된다.
+> - 소셜 연결 해제(unlink / revoke)에 실패해도 **탈퇴 처리는 계속 진행**한다. 사용자가 탈퇴하지 못하는 상태에 갇히지 않게 하기 위함이다.
+> - 온보딩 미완료 상태에서도 탈퇴할 수 있다.
 
 #### Request
 
@@ -267,7 +481,7 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
 Bearer eyJhbGciOiJIUzI1NiJ9...
 ```
 
-**Body** (Apple 로그인 유저만 필요)
+**Body**
 
 ```json
 {
@@ -277,6 +491,7 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
 
 - [선택] `authorizationCode` (String): Apple 토큰 revoke 용 인가 코드
     - **Apple 로그인 유저는 필수.** App Store 심사 요건(연동 해제)에 해당한다.
+    - Kakao 유저는 생략한다.
 
 #### `성공` Response 204
 
@@ -286,8 +501,11 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
 
 **처리 순서**
 
-1. 소셜 연결 해제 (Kakao `unlink` / Apple `revoke`) — 실패해도 로그만 남기고 탈퇴는 계속 진행
-2. `correction_segments` → `feedbacks` → `letters` → `terms_agreements` → `users` 순서로 삭제
+1. 소셜 연결 해제 (Kakao `unlink` / Apple `revoke`) — **트랜잭션 밖에서** 수행하며, 실패해도 로그만 남기고 탈퇴는 계속 진행
+2. 계정을 탈퇴 상태로 전환하고 Refresh Token 을 무효화 (단일 트랜잭션)
+3. 유예기간(30일) 경과 후 배치가 유저 행을 삭제하면 약관 이력·편지·피드백·교정 조각·팁이 cascade 로 함께 제거된다 ([ERD §3.3](./ERD.md#33-삭제-전파))
+
+> 삭제 순서를 서버 코드가 지정하지 않는다. 유저 엔티티 하나를 삭제하면 JPA cascade 가 전 구간을 연쇄 삭제한다.
 
 #### `실패` Error Response
 
@@ -301,11 +519,17 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
 
 ---
 
-### 3.5 `PATCH /api/v1/users/nickname`
+### 3.7 `PATCH /api/v1/users/nickname`
 
 > **API 설명**
 > - 닉네임을 등록하거나 변경합니다.
 > - 온보딩(이름 입력)과 설정(이름 변경)이 동일한 API 를 사용합니다.
+>
+> **도메인 규칙**
+> - 닉네임은 Jolly 에게 보여줄 **표시용 이름**이므로 **중복을 허용**한다. 유니크 제약이 없어 중복 에러도 없다.
+> - 영문·숫자 1~20자만 허용한다. 길이는 **문자 수** 기준으로 세며 앱의 `10/20` 카운터와 일치한다.
+> - **검증은 길이 → 문자 순서로 수행한다.** 두 조건을 동시에 어겨도 먼저 걸린 사유 하나만 반환한다. 앱이 사유별로 다른 문구를 보여줘야 하기 때문이다.
+> - 변경 횟수에 제한이 없고, 이전 닉네임은 보관하지 않는다.
 
 #### Request
 
@@ -333,14 +557,16 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
 
 **검증 규칙**
 
-| 규칙 | 값 | code |
-| --- | --- | --- |
-| 길이 | 1 ~ 20자 (문자 수) | `USER_004` |
-| 허용 문자 | `^[A-Za-z0-9]{1,20}$` | `USER_003` |
-| 공백 · 특수기호 · 한글 | 불가 | `USER_003` |
+| 순서 | 규칙 | 값 | code |
+| --- | --- | --- | --- |
+| 1 | 길이 | 1 ~ 20자 (문자 수) | `USER_004` |
+| 2 | 허용 문자 | `^[A-Za-z0-9]+$` | `USER_003` |
+| — | 공백 · 특수기호 · 한글 | 불가 | `USER_003` |
+| — | 중복 | **허용** (표시용 이름) | — |
 
+- 정규식에 길이 수량자(`{1,20}`)를 넣지 않는다. 넣으면 길이 위반과 문자 위반이 같은 코드로 뭉개진다.
+- 21자 영문을 보내면 `USER_004`, 5자 한글을 보내면 `USER_003`, 21자 한글을 보내면 `USER_004` 다.
 - 앱은 사유별 문구(`공백을 포함할 수 없어요` / `특수 기호를 포함할 수 없어요` / `한글을 포함할 수 없어요`)를 클라이언트에서 판별해 표시한다. 서버는 최종 방어선이다.
-- 닉네임 **중복은 허용**한다 (표시용 이름).
 
 #### `성공` Response 200
 
@@ -362,28 +588,43 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
 }
 ```
 
+| code | status | 상황 |
+| --- | --- | --- |
+| `USER_003` | 400 | 공백 · 특수기호 · 한글 포함 |
+| `USER_004` | 400 | 1자 미만 또는 20자 초과 |
+| `USER_001` | 404 | 사용자를 찾을 수 없음 |
+
 ---
 
 ## 4. letter
 
-### 4.1 `POST /api/v1/letter`
+### 4.1 `POST /api/v1/letters`
 
 > **API 설명**
 > - 새로운 편지를 작성합니다.
 > - 편지가 저장되면 AI 피드백 프로세스가 트리거됩니다.
+> - 피드백은 비동기로 처리되며, 이 API 는 결과를 기다리지 않고 즉시 반환합니다.
+>
+> **도메인 규칙**
+> - 편지는 **전달 후 수정·삭제할 수 없다.** 수정·삭제 API 자체를 제공하지 않는다 (디자인 문구: *"전달된 편지는 다시 고칠 수 없어요."*).
+> - 본문은 **영어 전용, 1~500자**다. 한글이 섞이면 거부한다. 숫자·구두점·이모지는 허용한다.
+> - 편지 날짜는 **클라이언트가 보낸 작성 시각 + 타임존**으로 결정한다. 작성 화면의 `DATE:` 는 변경할 수 없는 UI 이므로 화면 표시와 항상 일치하며, 서버는 임의 날짜 조작만 차단한다.
+> - **하루 작성 개수 제한이 없다.** 같은 날짜에 여러 통을 쓰면 목록에 같은 날짜 카드가 여러 개 쌓인다.
+> - 생성 직후 상태는 항상 `SUBMITTED` 이고, 우표는 **아직 부여되지 않는다.** 피드백이 완료돼야 우표가 도착한다.
+> - **중복 전달은 서버가 막는다.** 동일 유저가 60초 이내에 같은 본문을 다시 보내면 새 편지를 만들지 않고 최초 편지를 `200 OK` 로 반환한다. 앱이 별도 헤더를 보낼 필요가 없다.
 
 #### Request
 
 **Endpoint**
 
 ```
-/api/v1/letter
+/api/v1/letters
 ```
 
 **Authorization 헤더**
 
 ```
-Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3MzEyMjg1ODIsImV4cCI6MTczMTIyODYxOH0.ZCvhG9hWexsMg-dpJrtFQBpYbXIwmWgZrYk6AlugQVU
+Bearer eyJhbGciOiJIUzI1NiJ9...
 ```
 
 **Body**
@@ -391,37 +632,58 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 ```json
 {
     "content": "I got flowers from a friend today...",
-    "letterDate": "2025-11-01"
+    "writtenAt": "2025-11-01T21:00:00",
+    "timeZone": "Asia/Seoul"
 }
 ```
 
 - [필수] `content` (String): 편지 내용 (최대 500자)
-- [필수] `letterDate` (LocalDate): 일기 날짜 (`YYYY-MM-DD`)
+- [필수] `writtenAt` (LocalDateTime): **기기 로컬 기준** 작성 시각 (`yyyy-MM-dd'T'HH:mm:ss`)
+- [필수] `timeZone` (String): IANA 타임존 ID (예: `Asia/Seoul`)
 
 **검증 규칙**
 
 | 규칙 | 상세 | code |
 | --- | --- | --- |
-| 필수 | `null` / 공백만 있는 값 불가 | `LETTER_001` |
-| 길이 | 1 ~ 500자 (문자 수, 공백 포함) | `LETTER_003` |
+| 필수 | `content` 가 `null` / 공백만 있는 값 불가 | `LETTER_001` |
+| 길이 | **500자 초과** 불가 (문자 수, 공백 포함) | `LETTER_003` |
 | 언어 | `[가-힣ㄱ-ㅎㅏ-ㅣ]` 포함 시 거부 | `LETTER_004` |
-| 날짜 | 서버 KST 기준 **오늘**이어야 함 ([Q2](#8-확인-필요-항목)) | `LETTER_005` |
+| 타임존 | `ZoneId` 로 해석 가능한 IANA ID | `LETTER_005` |
+| 작성 시각 | `writtenAt` + `timeZone` 으로 환산한 시각이 서버 현재 시각 기준 ±24시간 이내 | `LETTER_005` |
 
-- 편지 작성 화면의 `DATE:` 는 터치 · 변경이 불가하므로 `letterDate` 는 항상 오늘 날짜가 들어온다. 서버는 이를 검증한다.
-- 편지는 전달 후 **수정 · 삭제 불가**다.
-- 피드백은 **비동기 처리**되며, 이 API 는 LLM 응답을 기다리지 않고 즉시 반환한다.
+- 0자·공백은 `LETTER_001` 이 담당하므로 `LETTER_003` 은 **상한만** 판정한다. 두 코드의 담당 구간이 겹치지 않는다.
+- 편지 날짜(`date`)는 `writtenAt` 을 `timeZone` 기준으로 환산한 날짜다. 앱 작성 화면의 `DATE:` 표시와 항상 일치한다.
+- 하루에 쓸 수 있는 편지 **개수 제한은 없다.**
+- 편지는 전달 후 **수정 · 삭제할 수 없다.**
 
-#### `성공` Response 200
+#### `성공` Response 201
 
 ```json
 {
     "letterId": 16,
-    "createdAt": "2025-11-01T21:00:00"
+    "date": "2025-11-01",
+    "createdAt": "2025-11-01T21:00:03"
 }
 ```
 
 - [필수] `letterId` (Long): 편지 ID
-- [필수] `createdAt` (LocalDateTime): 저장시각
+- [필수] `date` (LocalDate): 편지 날짜 (`writtenAt` + `timeZone` 기준)
+- [필수] `createdAt` (LocalDateTime): 저장 시각 (요청의 `timeZone` 기준)
+
+#### `성공` Response 200 — 중복 전달
+
+동일 유저가 60초 이내에 같은 `content` 를 다시 보낸 경우다. 응답 본문은 **최초 편지의 생성 결과와 동일**하다.
+
+```json
+{
+    "letterId": 16,
+    "date": "2025-11-01",
+    "createdAt": "2025-11-01T21:00:03"
+}
+```
+
+- 앱은 201 과 200 을 구분할 필요 없이 동일하게 완료 화면으로 이동한다.
+- 새 편지가 만들어지지 않으므로 피드백도 중복 요청되지 않는다.
 
 #### `실패` Error Response
 
@@ -435,10 +697,11 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 
 | code | status | 상황 |
 | --- | --- | --- |
-| `LETTER_001` | 400 | `content` 가 `null` / 빈 값 |
+| `LETTER_001` | 400 | `content` 가 `null` / 빈 값 / 공백만 있는 값 |
 | `LETTER_003` | 400 | 500자 초과 |
 | `LETTER_004` | 400 | 한글 포함 |
-| `LETTER_005` | 400 | `letterDate` 가 오늘이 아님 |
+| `LETTER_005` | 400 | `writtenAt` / `timeZone` 이 올바르지 않음 |
+| `USER_005` | 400 | 온보딩 미완료 (§2.6) |
 
 ---
 
@@ -446,6 +709,15 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 
 > **API 설명**
 > - 특정 편지의 상세 내용과 도착한 피드백(교정문, 팁 등)을 조회합니다.
+> - 조회에 성공하면 해당 편지는 읽음 처리됩니다.
+>
+> **도메인 규칙**
+> - **본인 편지만** 조회할 수 있다. 타인의 편지는 존재 여부를 숨기기 위해 403 이 아닌 404 로 응답한다.
+> - 피드백 완료 전에도 응답은 성공하지만 `feedback` 이 `null` 이다. 앱은 완료 전 카드의 진입 자체를 막는다.
+> - 읽음 처리는 이 API 의 **부수 효과**다. 별도의 읽음 처리 API 는 없으며, 한 번 읽으면 다시 미열람으로 되돌아가지 않는다.
+> - 교정 결과는 원문 전체를 순서대로 자른 조각(`correctionSegments`)으로 내려간다. 조각을 이어붙이면 원문·교정문이 그대로 복원되는 것을 서버가 보장한다.
+> - 팁은 편지마다 0~3개다. 없을 수도 있다 (잘 쓴 편지).
+> - 우표는 **AI 가 편지 내용에 어울리는 것으로 고른다.** 우표 종류는 DB(`stamps` 테이블)가 관리하므로 운영 중 추가·교체될 수 있다. 앱은 `stampImage` URL 을 그대로 표시하고 **우표 종류를 코드로 분기하지 않는다.**
 
 #### Request
 
@@ -458,7 +730,7 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 **Authorization 헤더**
 
 ```
-Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3MzEyMjg1ODIsImV4cCI6MTczMTIyODYxOH0.ZCvhG9hWexsMg-dpJrtFQBpYbXIwmWgZrYk6AlugQVU
+Bearer eyJhbGciOiJIUzI1NiJ9...
 ```
 
 **Path Variable**
@@ -473,6 +745,7 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
     "date": "2025-11-01",
     "originalContent": "I got flowers from a friend today...",
     "status": "FEEDBACK_COMPLETED",
+    "stampImage": "https://cdn.dearjolly.com/stamps/flower_stamp.png",
     "feedback": {
         "feedbackId": 101,
         "correctedContent": "I received flowers from a friend today...",
@@ -505,26 +778,28 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 ```
 
 - [필수] `letterId` (Long): 편지 ID
-- [필수] `date` (LocalDate): 작성 날짜 (`yyyy-MM-dd`)
+- [필수] `date` (LocalDate): 편지 날짜 (`yyyy-MM-dd`)
 - [필수] `originalContent` (String): 원본 편지 내용
-- [필수] `status` (String): 편지 상태 (`SUBMITTED`, `FEEDBACK_COMPLETED`) — [Q1](#8-확인-필요-항목)
+- [필수] `status` (String): 편지 상태 (`SUBMITTED`, `FEEDBACK_IN_PROGRESS`, `FEEDBACK_COMPLETED`)
+- [선택] `stampImage` (String): 우표 이미지 URL (피드백 완료 전에는 `null`)
 - [선택] `feedback` (Object): 피드백 정보 (**피드백 생성 전일 경우 `null`**)
     - [필수] `feedbackId` (Long): 피드백 ID
     - [필수] `correctedContent` (String): 교정된 전체 내용
-    - [필수] `tips` (Array&lt;String&gt;): 피드백 팁 목록 (0~3개, 없으면 `[]`) — [Q3](#8-확인-필요-항목)
-    - [필수] `correctionSegments` (Array): 교정 세그먼트 리스트
+    - [필수] `tips` (Array&lt;String&gt;): 피드백 팁 목록 (0~3개, 없으면 `[]`)
+    - [필수] `correctionSegments` (Array): 교정 세그먼트 리스트 (1개 이상)
         - [필수] `sequence` (Integer): 문장 내 순서 (1부터 시작)
         - [필수] `originalText` (String): 원본 텍스트 조각
         - [필수] `correctedText` (String): 교정된 텍스트 조각
-        - [필수] `type` (String): 수정 여부 (`UNCHANGED`, `MODIFIED`)
+        - [필수] `type` (String): 수정 여부 (`UNCHANGED`, `MODIFIED`) — DB 컬럼명은 `correction_type` 이지만 **응답 필드명은 `type`** 이다
 
 **렌더링 계약**
 
-- `correctionSegments` 를 `sequence` 순서대로 이어붙이면 **`originalText` 는 원문 전체**, **`correctedText` 는 `correctedContent` 전체**와 정확히 일치한다. 앱은 별도 인덱스 계산 없이 순차 렌더링만 하면 된다.
+- `correctionSegments` 를 `sequence` 순서대로 이어붙이면 **`originalText` 는 `originalContent` 전체**, **`correctedText` 는 `correctedContent` 전체**와 정확히 일치한다. 앱은 인덱스 계산 없이 순차 렌더링만 하면 된다.
 - `type == "UNCHANGED"` → 검은 글씨 그대로 출력
 - `type == "MODIFIED"` → `originalText` 를 빨간 취소선, 바로 뒤에 `correctedText` 를 초록 하이라이트로 출력
 - 공백은 세그먼트 문자열에 포함해 내려준다 (앱에서 공백을 임의로 추가하지 않음).
 - 삭제 제안은 `type == "MODIFIED"` + `correctedText == ""` 로 표현한다.
+- `tips` 가 `[]` 면 팁 영역을 표시하지 않는다.
 
 #### `실패` Error Response
 
@@ -539,8 +814,7 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 | code | status | 상황 |
 | --- | --- | --- |
 | `LETTER_002` | 404 | 존재하지 않는 편지 **또는 타인의 편지** (존재 여부를 노출하지 않기 위해 403 대신 404) |
-
-**부수 효과**: 조회 성공 시 해당 편지를 **읽음 처리(`isRead = true`)** 한다. 별도의 읽음 처리 API 는 두지 않는다.
+| `USER_005` | 400 | 온보딩 미완료 (§2.6) |
 
 ---
 
@@ -548,6 +822,16 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 
 > **API 설명**
 > - 홈 화면에 진입했을 때 보여질 편지 리스트를 조회합니다.
+> - 헤더 영역에 필요한 닉네임 · 우표 수를 함께 반환하므로, 홈 진입 시 이 API 호출 한 번이면 됩니다.
+>
+> **도메인 규칙**
+> - **본인 편지만** 조회된다. 유저는 서버 인증 컨텍스트에서 가져오며 파라미터로 받지 않는다.
+> - `totalStampCount` 는 **피드백이 완료된 편지 수**다. 작성한 편지 수와 다르다.
+> - 편지를 빼먹은 날이 눈에 띄지 않도록 **캘린더가 아니라 기록이 쌓이는 목록** 구조다. 비어 있는 날짜는 응답에 나타나지 않는다.
+> - 피드백 완료 전 카드는 우표가 없고(`stampImage: null`) 상세로 들어갈 수 없다.
+> - 정렬은 **서버가 처리**한다. 페이징된 일부만 앱에서 뒤집으면 전체 정렬이 깨지기 때문이다.
+> - `stampImage` 는 DB 가 관리하는 우표 마스터의 이미지 URL 이다. 종류가 운영 중 늘어날 수 있으므로 앱은 **URL 을 그대로 렌더링**한다.
+> - 온보딩 가드(§2.6)를 통과한 유저만 호출할 수 있으므로 `nickname` 은 **항상 non-null** 이다.
 
 #### Request
 
@@ -560,14 +844,16 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 **Authorization 헤더**
 
 ```
-Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3MzEyMjg1ODIsImV4cCI6MTczMTIyODYxOH0.ZCvhG9hWexsMg-dpJrtFQBpYbXIwmWgZrYk6AlugQVU
+Bearer eyJhbGciOiJIUzI1NiJ9...
 ```
 
 **Query Parameter**
 
-- [선택] `page`: 페이지 번호 (기본값 0)
-- [선택] `size`: 페이지 크기 (기본값 10)
-- [선택] `sort`: 정렬 기준 (`LATEST` 기본값, `OLDEST`) — 홈 화면의 `최신순 / 오래된 순` 토글용 ([Q4](#8-확인-필요-항목))
+- [선택] `page`: 페이지 번호 (기본값 0, 0 이상)
+- [선택] `size`: 페이지 크기 (기본값 10, 1~50)
+- [선택] `sort`: 정렬 기준 (기본값 `LATEST`)
+    - `LATEST`: 최신순
+    - `OLDEST`: 오래된 순
 
 #### `성공` Response 200
 
@@ -579,18 +865,26 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
         {
             "letterId": 15,
             "date": "2025-11-01",
-            "summary": "I got flowers from a friend today. It really ...",
+            "summary": "I got flowers from a friend today. It really touc",
             "status": "FEEDBACK_COMPLETED",
             "isRead": false,
-            "stampImage": "https://s3.../flower_stamp.png"
+            "stampImage": "https://cdn.dearjolly.com/stamps/flower_stamp.png"
         },
         {
             "letterId": 12,
             "date": "2025-10-30",
-            "summary": "Hi! Jolly. I made a new friend at a Halloween ...",
+            "summary": "Hi! Jolly. I made a new friend at a Halloween part",
             "status": "FEEDBACK_COMPLETED",
             "isRead": true,
-            "stampImage": "https://s3.../pumpkin_stamp.png"
+            "stampImage": "https://cdn.dearjolly.com/stamps/pumpkin_stamp.png"
+        },
+        {
+            "letterId": 11,
+            "date": "2025-10-29",
+            "summary": "Lately I've been really worried about my new job a",
+            "status": "SUBMITTED",
+            "isRead": false,
+            "stampImage": null
         }
     ],
     "hasNext": true
@@ -601,12 +895,13 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 - [필수] `totalStampCount` (Integer): 모은 우표 총 개수
 - [필수] `letters` (Array): 편지 목록
     - [필수] `letterId` (Long): 편지 ID
-    - [필수] `date` (LocalDate): 작성 날짜 (`yyyy-MM-dd`)
-    - [필수] `summary` (String): 편지 내용 요약 (목록 노출용, 원문 앞 30자)
+    - [필수] `date` (LocalDate): 편지 날짜 (`yyyy-MM-dd`)
+    - [필수] `summary` (String): 편지 내용 미리보기 (**원문 앞 50자**, 말줄임은 클라이언트 처리)
     - [필수] `status` (String): 편지 상태
         - `SUBMITTED`: 제출됨 (피드백 대기중)
+        - `FEEDBACK_IN_PROGRESS`: 피드백 생성 중
         - `FEEDBACK_COMPLETED`: 피드백 완료
-    - [필수] `isRead` (Boolean): 피드백 확인 여부 (`false`면 NEW 뱃지 노출)
+    - [필수] `isRead` (Boolean): 피드백 열람 여부
     - [선택] `stampImage` (String): 우표 이미지 URL (피드백 완료 전에는 `null`)
 - [필수] `hasNext` (Boolean): 다음 페이지 존재 여부
 
@@ -614,12 +909,16 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 
 | 조건 | 표시 |
 | --- | --- |
-| `status != FEEDBACK_COMPLETED` | 회색 `soon` 우표, `ic_more_sm` 미노출, **터치 불가** |
-| `status == FEEDBACK_COMPLETED` | `stampImage` 표시, `ic_more_sm` 노출, **카드 전체 영역** 터치 시 상세 이동 |
-| `status == FEEDBACK_COMPLETED && isRead == false` | 날짜 앞 빨간 점 |
+| `status != "FEEDBACK_COMPLETED"` (`SUBMITTED` · `FEEDBACK_IN_PROGRESS`) | 회색 `soon` 우표, `ic_more_sm` 미노출, **터치 불가** |
+| `status == "FEEDBACK_COMPLETED"` | `stampImage` 표시, `ic_more_sm` 노출, **카드 전체 영역** 터치 시 상세 이동 |
+| `status == "FEEDBACK_COMPLETED" && isRead == false` | **날짜 앞 빨간 점** |
 
+- 미열람 표시는 **피드백이 완료된 편지에만** 적용한다. 완료 전 편지도 `isRead` 는 `false` 지만 빨간 점을 표시하지 않는다.
 - `totalStampCount` 는 **작성한 편지 수가 아니라** 피드백이 완료되어 우표가 도착한 편지 수다. (편지 3건 작성 + 1건 피드백 대기 → `totalStampCount = 2`)
-- `SUBMITTED` 항목이 있으면 앱이 화면 재진입 · 새로고침 시 재조회해 상태 변화를 확인한다 (폴링 전용 API 없음).
+- 정렬은 `date` 기준이며, 같은 날짜 안에서는 `letterId` 로 정렬한다 (`LATEST` → 내림차순, `OLDEST` → 오름차순).
+- 헤더 필드(`nickname`, `totalStampCount`)는 `page > 0` 요청에서도 동일하게 내려간다. 앱은 첫 페이지 값만 사용하면 된다.
+- `FEEDBACK_COMPLETED` 가 아닌 항목이 있으면 앱이 화면 재진입 · 새로고침 시 재조회해 상태 변화를 확인한다. 앱은 `SUBMITTED` 와 `FEEDBACK_IN_PROGRESS` 를 동일하게 처리하면 된다.
+- 내부 상태 `FEEDBACK_FAILED` 는 응답에서 `SUBMITTED` 로 치환돼 내려간다.
 
 #### `실패` Error Response
 
@@ -631,12 +930,24 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 }
 ```
 
+| code | status | 상황 |
+| --- | --- | --- |
+| `USER_001` | 404 | 사용자를 찾을 수 없음 |
+| `USER_005` | 400 | 온보딩 미완료 (§2.6) |
+| `COMMON_001` | 400 | `page` · `size` · `sort` 가 허용 범위를 벗어남 |
+
 ---
 
 ### 4.4 `GET /api/v1/home`
 
 > **API 설명**
-> - 홈 화면에 진입했을 때 보여질 유저 정보(닉네임, 모은 우표 수)를 조회합니다.
+> - 홈 화면 헤더에 보여질 유저 정보(닉네임, 모은 우표 수)를 조회합니다.
+> - 편지 목록 없이 헤더 정보만 갱신할 때 사용합니다. (홈 진입 시에는 `GET /api/v1/letters` 한 번이면 됩니다.)
+>
+> **도메인 규칙**
+> - `totalStampCount` 는 **피드백이 완료되어 우표가 도착한 편지 수**다. 편지를 써도 검토가 끝나기 전에는 늘지 않는다.
+> - `GET /api/v1/letters` 의 동일 필드와 항상 같은 값을 반환한다. 두 API 는 같은 서비스 메서드를 호출한다.
+> - 온보딩 가드(§2.6)를 통과한 유저만 호출할 수 있으므로 `nickname` 은 **항상 non-null** 이다.
 
 #### Request
 
@@ -649,7 +960,7 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 **Authorization 헤더**
 
 ```
-Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3MzEyMjg1ODIsImV4cCI6MTczMTIyODYxOH0.ZCvhG9hWexsMg-dpJrtFQBpYbXIwmWgZrYk6AlugQVU
+Bearer eyJhbGciOiJIUzI1NiJ9...
 ```
 
 **Query Parameter**: 없음
@@ -676,16 +987,25 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 }
 ```
 
-> ⚠️ 초안에서 이 API 의 Endpoint 가 `/api/v1/letters` 로, Response 가 편지 리스트 응답으로 복사되어 있었다. 위 내용으로 정정했다. `/api/v1/letters` 와 응답 필드가 중복되는 문제는 [Q5](#8-확인-필요-항목) 참고.
+| code | status | 상황 |
+| --- | --- | --- |
+| `USER_001` | 404 | 사용자를 찾을 수 없음 |
+| `USER_005` | 400 | 온보딩 미완료 (§2.6) |
 
 ---
 
-## 5. version
+## 5. global
 
 ### 5.1 `GET /api/v1/version`
 
 > **API 설명**
 > - 앱 최소 지원 버전과 정책 페이지 URL 을 조회합니다.
+>
+> **도메인 규칙**
+> - 앱 버전이 `minSupportedVersion` 미만이면 앱이 강제 업데이트를 유도한다.
+> - **공지사항 · 개인정보처리방침 · 이용약관은 서버 API 로 제공하지 않는다.** 이 응답의 웹뷰 링크로 처리한다.
+> - 설정 화면 하단의 `현재 버전` 표기는 앱 로컬 값이며 이 응답과 무관하다.
+> - 인증도 온보딩도 필요 없다. 로그인 전에 호출할 수 있어야 하기 때문이다.
 
 #### Request
 
@@ -722,7 +1042,8 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 - [선택] `noticeUrl` (String): 공지사항 URL
 
 - 설정 화면의 `현재 버전 1.0.0 (MVP)` 는 앱 로컬 값이고, 이 API 는 업데이트 유도 · 정책 링크 제공용이다.
-- 공지사항 · 개인정보처리방침은 별도 API 없이 **웹뷰 링크**로 처리한다.
+- 공지사항 · 개인정보처리방침 · 이용약관은 별도 API 없이 **웹뷰 링크**로 처리한다.
+- 약관 버전은 이 응답에 포함하지 않는다. MVP 는 재동의를 유도하지 않기 때문이다 ([기능명세 §3.2.1](./기능명세.md#321-약관-동의)).
 
 ---
 
@@ -730,120 +1051,60 @@ Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJp
 
 | Enum | 값 | 비고 |
 | --- | --- | --- |
-| `Provider` | `KAKAO`, `APPLE` | |
+| `OauthProvider` | `KAKAO`, `APPLE` | 요청/응답의 `provider` 필드. ERD 와 클래스명을 동일하게 맞춘다 |
 | `TermsType` | `SERVICE`, `PRIVACY`, `MARKETING` | `MARKETING` 만 선택 동의 |
-| `Status` (letter) | `SUBMITTED`, `FEEDBACK_COMPLETED` | 내부 상태 `FEEDBACK_FAILED` 는 앱에 `SUBMITTED` 로 내려보냄 — [Q1](#8-확인-필요-항목) |
-| `SegmentType` | `UNCHANGED`, `MODIFIED` | |
+| `Status` (letter) | `SUBMITTED`, `FEEDBACK_IN_PROGRESS`, `FEEDBACK_COMPLETED` | `FEEDBACK_IN_PROGRESS` 는 피드백 생성 중. 앱은 `SUBMITTED` 와 동일하게 렌더링한다. 내부 상태 `FEEDBACK_FAILED` 는 API 응답에서 `SUBMITTED` 로 변환해 내려보낸다 |
+| `CorrectionType` | `UNCHANGED`, `MODIFIED` | 응답 필드명은 `type`, DB 컬럼명은 `correction_type` |
 | `Sort` | `LATEST`, `OLDEST` | |
+
+`Role`(`ROLE_USER` / `ROLE_ADMIN`), `UserStatus`(`ACTIVE` / `WITHDRAWN`) 는 서버 내부 enum 이며 API 응답에 노출되지 않는다. 정의는 [ERD §4](./ERD.md#4-enum-정의) 참고.
 
 ---
 
 ## 7. 에러 코드
 
+`{도메인}_{일련번호}` 형식을 정본으로 한다. `ErrorCode` enum 은 이 표를 그대로 옮긴 것이어야 한다.
+
 ### 7.1 AUTH
 
-| code | status | message |
-| --- | --- | --- |
-| `AUTH_001` | 400 | 지원하지 않는 로그인 방식입니다. |
-| `AUTH_002` | 401 | 소셜 로그인 인증에 실패했습니다. |
-| `AUTH_003` | 502 | 소셜 로그인 서버와 통신하지 못했습니다. |
-| `AUTH_004` | 401 | 만료된 토큰입니다. |
-| `AUTH_005` | 401 | 유효하지 않은 토큰입니다. |
-| `AUTH_006` | 403 | 접근 권한이 없습니다. |
+| code | status | message | 발생 지점 |
+| --- | --- | --- | --- |
+| `AUTH_001` | 400 | 지원하지 않는 로그인 방식입니다. | `POST /auth/login` |
+| `AUTH_002` | 401 | 소셜 로그인 인증에 실패했습니다. | `POST /auth/login` |
+| `AUTH_003` | 502 | 소셜 로그인 서버와 통신하지 못했습니다. | `POST /auth/login` |
+| `AUTH_004` | 401 | 로그인이 만료되었습니다. 다시 로그인해주세요. | `POST /auth/reissue` |
+| `AUTH_005` | 401 | 유효하지 않은 토큰입니다. | 인증 필터 공통 (§2.3) |
+| `AUTH_006` | 403 | 접근 권한이 없습니다. | Security `AccessDeniedHandler` 공통 (§2.3) |
+| `AUTH_007` | 401 | 탈퇴한 계정입니다. 다시 로그인해주세요. | 인증 필터 공통 — `status = WITHDRAWN` (§2.3) |
 
 ### 7.2 USER
 
-| code | status | message |
-| --- | --- | --- |
-| `USER_001` | 404 | 사용자를 찾을 수 없습니다. |
-| `USER_002` | 400 | 필수 약관에 모두 동의해야 합니다. |
-| `USER_003` | 400 | 닉네임은 공백, 특수기호, 한글 없이 작성해야 합니다. |
-| `USER_004` | 400 | 닉네임은 1자 이상 20자 이하여야 합니다. |
-| `USER_005` | 400 | 온보딩을 먼저 완료해야 합니다. |
+| code | status | message | 발생 지점 |
+| --- | --- | --- | --- |
+| `USER_001` | 404 | 사용자를 찾을 수 없습니다. | 유저 조회가 필요한 모든 API |
+| `USER_002` | 400 | 필수 약관에 모두 동의해야 합니다. | `POST /users/terms` |
+| `USER_003` | 400 | 닉네임은 공백, 특수기호, 한글 없이 작성해야 합니다. | `PATCH /users/nickname` |
+| `USER_004` | 400 | 닉네임은 1자 이상 20자 이하여야 합니다. | `PATCH /users/nickname` |
+| `USER_005` | 400 | 온보딩을 먼저 완료해야 합니다. | 온보딩 가드 (§2.6) |
 
 ### 7.3 LETTER
 
-| code | status | message |
-| --- | --- | --- |
-| `LETTER_001` | 400 | 편지 내용은 null일 수 없습니다. |
-| `LETTER_002` | 404 | 존재하지 않는 편지입니다. |
-| `LETTER_003` | 400 | 편지 내용은 500자를 초과할 수 없습니다. |
-| `LETTER_004` | 400 | 편지는 영어로만 작성할 수 있습니다. |
-| `LETTER_005` | 400 | 편지 날짜가 올바르지 않습니다. |
+| code | status | message | 발생 지점 |
+| --- | --- | --- | --- |
+| `LETTER_001` | 400 | 편지 내용은 null일 수 없습니다. | `POST /letters` |
+| `LETTER_002` | 404 | 존재하지 않는 편지입니다. | `GET /letters/{letterId}` |
+| `LETTER_003` | 400 | 편지 내용은 500자를 초과할 수 없습니다. | `POST /letters` |
+| `LETTER_004` | 400 | 편지는 영어로만 작성할 수 있습니다. | `POST /letters` |
+| `LETTER_005` | 400 | 편지 작성 시각 정보가 올바르지 않습니다. | `POST /letters` |
 
 ### 7.4 COMMON
 
-| code | status | message |
-| --- | --- | --- |
-| `COMMON_001` | 400 | 잘못된 요청입니다. |
-| `COMMON_002` | 404 | 요청하신 경로를 찾을 수 없습니다. |
-| `COMMON_003` | 405 | 지원하지 않는 요청 방식입니다. |
-| `COMMON_004` | 429 | 요청이 너무 많습니다. 잠시 후 다시 시도해주세요. |
-| `COMMON_005` | 500 | 일시적인 오류가 발생했습니다. |
+전부 `GlobalExceptionHandler` 가 공통으로 생산한다. 개별 API 의 실패 표에는 적지 않는다 (§2.3).
 
----
-
-## 8. 확인 필요 항목
-
-초안 검토 중 발견한 충돌 · 결정 필요 사항. **구현 착수 전 확정 필요**.
-
-### Q1. `status` enum 값이 초안 내에서 충돌한다 ⚠️
-
-- JSON 예시: `"status": "FEEDBACK_COMPLETED"`
-- 필드 설명: `DRAFT`(작성중), `SUBMITTED`(제출됨), `ANALYZED`(피드백완료)
-
-→ 같은 필드에 두 가지 값 체계가 섞여 있다. **본 문서는 JSON 예시를 따라 `FEEDBACK_COMPLETED` 로 통일**했다.
-
-추가로, MVP 에는 **임시저장 기능이 없고**(작성 → 전달하기 → 수정 불가) 편지는 생성 즉시 피드백이 트리거되므로 `DRAFT` 는 사용되지 않는다. 제안하는 최종 값:
-
-| 값 | 의미 | 앱 표시 |
-| --- | --- | --- |
-| `SUBMITTED` | 제출됨, 피드백 대기 | 회색 `soon` 우표 |
-| `FEEDBACK_COMPLETED` | 피드백 완료 | 우표 노출, 상세 진입 가능 |
-| `FEEDBACK_FAILED` | (내부용) 피드백 실패 | 앱에는 `SUBMITTED` 로 내려 실패를 노출하지 않음 |
-
-### Q2. `letterDate` 를 클라이언트가 보내는 게 맞는가?
-
-작성 화면의 `DATE:` 는 **터치 · 변경이 불가**하다(기획 주석). 즉 항상 오늘 날짜다.
-
-- **권장**: 요청 필드는 유지하되 **서버가 KST 기준 오늘과 일치하는지 검증**(`LETTER_005`)한다. 과거/미래 날짜로 기록을 조작할 수 없게 된다.
-- 대안: 필드를 아예 받지 않고 서버 시각으로 설정. 단, 자정 근처에서 앱 표시 날짜와 어긋날 수 있다.
-
-### Q3. `tip` 이 단일 String 이면 디자인을 구현할 수 없다 ⚠️
-
-디자인에 **`검토하기-팁없음` / `팁단일` / `팁여러개`** 세 가지 상태가 있고, 팁여러개 시안은 팁 카드가 2개 분리되어 있다.
-
-- 초안: `tip` (String)
-- **본 문서: `tips` (Array&lt;String&gt;)** 로 변경 — 0개면 `[]`(팁 영역 미표시), n개면 카드 n개
-
-단일 String 을 유지하면 앱이 개행 기준으로 쪼개야 해서 취약하다.
-
-### Q4. 정렬 파라미터가 초안에 없다
-
-홈 화면에 `최신순 / 오래된 순` 토글이 있다. `sort` 쿼리 파라미터를 추가했다. 클라이언트 정렬로 처리할 경우 페이징과 충돌하므로 **서버 정렬 권장**.
-
-### Q5. `/api/v1/letters` 와 `/api/v1/home` 의 응답이 중복된다
-
-초안에서는 `/letters` 응답에도 `nickname`, `totalStampCount` 가 포함되어 있다. 두 가지 선택지:
-
-| 안 | 내용 | 장단점 |
-| --- | --- | --- |
-| **A (현재 문서)** | `/letters` 에 헤더 정보 포함 + `/home` 도 유지 | 홈 진입 시 **1회 호출**로 끝남. `/home` 은 위젯 등 확장용으로 남김 |
-| B | `/letters` 는 목록만, `/home` 은 헤더만 | 책임 분리는 깔끔하나 홈 진입 시 항상 2회 호출 |
-
-→ 화면 성능상 **A 권장**. B 로 간다면 `/letters` 응답에서 `nickname`, `totalStampCount` 를 제거해야 한다.
-
-### Q6. 토큰 재발급 · 로그아웃 API 가 없다 ⚠️
-
-- **재발급**: Access Token 만료가 30분이므로 `POST /api/v1/auth/reissue` 가 없으면 30분마다 재로그인해야 한다. **MVP 필수로 판단**.
-- **로그아웃**: 설정 화면에 버튼이 있다. 서버에서 Refresh Token 을 무효화하려면 `POST /api/v1/auth/logout` 이 필요하고, 클라이언트 토큰 폐기만으로 처리한다면 API 는 불필요하다.
-
-### Q7. 기타
-
-| 항목 | 내용 |
-| --- | --- |
-| `POST /letter` 응답 코드 | 초안은 `200`. REST 관례상 `201 Created` 이나, **초안대로 200 유지**했다 |
-| `/letter` vs `/letters` | 생성만 단수라 혼동 여지가 있다. `POST /api/v1/letters` 통일 검토 |
-| `summary` 길이 | 원문 앞 **30자**로 가정했다. 디자인 확정 시 조정 필요 |
-| `stampImage` | S3 URL 방식이면 CDN 캐싱 헤더 설정 필요. 앱 로컬 리소스(enum) 방식 대비 네트워크 비용이 있다 |
-| 하루 작성 개수 제한 | 현재 명세는 **제한 없음**. 하루 1통 제한 시 `LETTER_006` 추가 필요 |
+| code | status | message | 발생 지점 |
+| --- | --- | --- | --- |
+| `COMMON_001` | 400 | 잘못된 요청입니다. | 바디 파싱 실패, 타입 불일치, 쿼리 파라미터 제약 위반 |
+| `COMMON_002` | 404 | 요청하신 경로를 찾을 수 없습니다. | 미정의 경로 |
+| `COMMON_003` | 405 | 지원하지 않는 요청 방식입니다. | 미지원 HTTP 메서드 |
+| `COMMON_004` | 429 | 요청이 너무 많습니다. 잠시 후 다시 시도해주세요. | Rate limit 초과 |
+| `COMMON_005` | 500 | 일시적인 오류가 발생했습니다. | 처리되지 않은 서버 오류 |

--- a/docs/API명세.md
+++ b/docs/API명세.md
@@ -1,0 +1,849 @@
+# Dear Jolly — API 명세서 (MVP)
+
+> 도메인/기능 배경은 [기능명세.md](./기능명세.md) 참고. 이 문서는 **요청/응답 계약**만 다룬다.
+> letter 도메인 4개 API 는 팀 초안을 그대로 반영했고, user / version 도메인은 동일한 형식으로 확장한 **제안**이다.
+
+| 항목 | 내용 |
+| --- | --- |
+| 문서 버전 | v1.1 |
+| Base URL | `https://{host}` |
+| 인증 | `Authorization: Bearer {accessToken}` |
+| Content-Type | `application/json; charset=UTF-8` |
+| 시간대 | `Asia/Seoul` (KST) |
+| 날짜 포맷 | `LocalDate` → `yyyy-MM-dd` / `LocalDateTime` → `yyyy-MM-dd'T'HH:mm:ss` |
+
+---
+
+## 1. 엔드포인트 목록
+
+| # | 도메인 | Method | 엔드포인트 | 설명 | 인증 | 상태 |
+| --- | --- | --- | --- | --- | :---: | --- |
+| 1 | user | `POST` | `/api/v1/auth/login` | 소셜 로그인 (회원가입 포함) | — | 임시 |
+| 2 | user | `POST` | `/api/v1/users/terms` | 약관 동의 | ✔ | 제안 |
+| 3 | user | `GET` | `/api/v1/users` | 계정 정보 조회 | ✔ | 제안 |
+| 4 | user | `DELETE` | `/api/v1/users` | 회원 탈퇴 | ✔ | 제안 |
+| 5 | user | `PATCH` | `/api/v1/users/nickname` | 닉네임 설정 | ✔ | 확정 |
+| 6 | letter | `POST` | `/api/v1/letter` | 단일 편지 작성 + 피드백 요청 | ✔ | **초안 확정** |
+| 7 | letter | `GET` | `/api/v1/letters/{letterId}` | 편지 및 피드백 상세 조회 | ✔ | **초안 확정** |
+| 8 | letter | `GET` | `/api/v1/letters` | 전체 편지 리스트 조회 | ✔ | **초안 확정** |
+| 9 | letter | `GET` | `/api/v1/home` | 닉네임, 모은 우표 수 조회 | ✔ | **초안 확정** |
+| 10 | version | `GET` | `/api/v1/version` | 최소 지원 버전 조회 | — | 제안 |
+
+⚠️ 초안 검토 중 발견한 충돌 사항이 있다. 구현 전 [8. 확인 필요 항목](#8-확인-필요-항목) 을 먼저 확정할 것.
+
+---
+
+## 2. 공통 규약
+
+### 2.1 에러 응답 포맷
+
+```json
+{
+    "status": 400,
+    "code": "LETTER_001",
+    "message": "편지 내용은 null일 수 없습니다."
+}
+```
+
+- [필수] `status` (Integer): HTTP 상태 코드
+- [필수] `code` (String): `{도메인}_{일련번호}` 형식
+- [필수] `message` (String): 에러 메시지
+
+전체 코드 목록은 [7. 에러 코드](#7-에러-코드) 참고.
+
+### 2.2 인증
+
+| 항목 | 값 |
+| --- | --- |
+| 헤더 | `Authorization: Bearer {accessToken}` |
+| Access Token 만료 | 30분 |
+| Refresh Token 만료 | 14일 |
+| 인증 불필요 | `POST /api/v1/auth/login`, `GET /api/v1/version` |
+
+---
+
+## 3. user
+
+### 3.1 `POST /api/v1/auth/login`
+
+> **API 설명**
+> - 카카오 / 애플 소셜 로그인을 수행합니다.
+> - 가입되지 않은 유저라면 회원가입을 함께 처리합니다.
+
+#### Request
+
+**Endpoint**
+
+```
+/api/v1/auth/login
+```
+
+**Authorization 헤더**: 불필요
+
+**Body**
+
+```json
+{
+    "provider": "KAKAO",
+    "token": "IwGRZ8bLXsC0hR..."
+}
+```
+
+- [필수] `provider` (String): 로그인 수단 (`KAKAO`, `APPLE`)
+- [필수] `token` (String): 소셜 인증 토큰
+    - `KAKAO`: 앱에서 발급받은 access token
+    - `APPLE`: identity token (JWT)
+
+#### `성공` Response 200
+
+```json
+{
+    "accessToken": "eyJhbGciOiJIUzI1NiJ9...",
+    "refreshToken": "eyJhbGciOiJIUzI1NiJ9...",
+    "userId": 1,
+    "isNewUser": true,
+    "termsAgreed": false,
+    "nicknameRegistered": false
+}
+```
+
+- [필수] `accessToken` (String): 액세스 토큰
+- [필수] `refreshToken` (String): 리프레시 토큰
+- [필수] `userId` (Long): 유저 ID
+- [필수] `isNewUser` (Boolean): 이번 요청으로 가입된 유저인지 여부
+- [필수] `termsAgreed` (Boolean): 필수 약관 동의 완료 여부
+- [필수] `nicknameRegistered` (Boolean): 닉네임 등록 여부
+
+**앱 분기**
+
+| 조건 | 이동 화면 |
+| --- | --- |
+| `termsAgreed == false` | 온보딩 – 약관동의 |
+| `termsAgreed == true && nicknameRegistered == false` | 온보딩 – 닉네임 |
+| 둘 다 `true` | 홈 |
+
+#### `실패` Error Response
+
+```json
+{
+    "status": 401,
+    "code": "AUTH_002",
+    "message": "소셜 로그인 인증에 실패했습니다."
+}
+```
+
+| code | status | 상황 |
+| --- | --- | --- |
+| `AUTH_001` | 400 | 지원하지 않는 `provider` |
+| `AUTH_002` | 401 | 소셜 토큰 검증 실패 |
+| `AUTH_003` | 502 | 카카오 / 애플 서버 통신 실패 |
+
+---
+
+### 3.2 `POST /api/v1/users/terms`
+
+> **API 설명**
+> - 온보딩 약관 동의 내역을 저장합니다.
+> - 필수 약관(`SERVICE`, `PRIVACY`)에 모두 동의해야 통과합니다.
+
+#### Request
+
+**Endpoint**
+
+```
+/api/v1/users/terms
+```
+
+**Authorization 헤더**
+
+```
+Bearer eyJhbGciOiJIUzI1NiJ9...
+```
+
+**Body**
+
+```json
+{
+    "agreements": [
+        { "type": "SERVICE",   "agreed": true },
+        { "type": "PRIVACY",   "agreed": true },
+        { "type": "MARKETING", "agreed": false }
+    ]
+}
+```
+
+- [필수] `agreements` (Array): 약관 동의 목록
+    - [필수] `type` (String): 약관 종류 (`SERVICE`, `PRIVACY`, `MARKETING`)
+    - [필수] `agreed` (Boolean): 동의 여부
+
+#### `성공` Response 200
+
+```json
+{
+    "termsAgreed": true
+}
+```
+
+- [필수] `termsAgreed` (Boolean): 필수 약관 동의 완료 여부
+
+#### `실패` Error Response
+
+```json
+{
+    "status": 400,
+    "code": "USER_002",
+    "message": "필수 약관에 모두 동의해야 합니다."
+}
+```
+
+---
+
+### 3.3 `GET /api/v1/users`
+
+> **API 설명**
+> - 설정 화면에 표시할 계정 정보를 조회합니다.
+
+#### Request
+
+**Endpoint**
+
+```
+/api/v1/users
+```
+
+**Authorization 헤더**
+
+```
+Bearer eyJhbGciOiJIUzI1NiJ9...
+```
+
+#### `성공` Response 200
+
+```json
+{
+    "nickname": "ilovesally",
+    "provider": "KAKAO",
+    "email": "kakao_user@email.com",
+    "marketingAgreed": true,
+    "appVersion": "1.0.0"
+}
+```
+
+- [필수] `nickname` (String): 유저 닉네임
+- [필수] `provider` (String): 로그인 수단 (`KAKAO`, `APPLE`) — 앱에서 아이콘 매핑
+- [선택] `email` (String): 소셜 계정 이메일 (Apple private relay 등 미제공 시 `null`)
+- [필수] `marketingAgreed` (Boolean): 마케팅 수신 동의 여부
+- [선택] `appVersion` (String): 표시용 서비스 버전
+
+#### `실패` Error Response
+
+```json
+{
+    "status": 404,
+    "code": "USER_001",
+    "message": "사용자를 찾을 수 없습니다."
+}
+```
+
+---
+
+### 3.4 `DELETE /api/v1/users`
+
+> **API 설명**
+> - 회원 탈퇴를 처리합니다.
+> - 모든 편지와 계정 정보가 삭제되며 복구할 수 없습니다.
+
+#### Request
+
+**Endpoint**
+
+```
+/api/v1/users
+```
+
+**Authorization 헤더**
+
+```
+Bearer eyJhbGciOiJIUzI1NiJ9...
+```
+
+**Body** (Apple 로그인 유저만 필요)
+
+```json
+{
+    "authorizationCode": "c1a2b3d4e5..."
+}
+```
+
+- [선택] `authorizationCode` (String): Apple 토큰 revoke 용 인가 코드
+    - **Apple 로그인 유저는 필수.** App Store 심사 요건(연동 해제)에 해당한다.
+
+#### `성공` Response 204
+
+```
+(No Content)
+```
+
+**처리 순서**
+
+1. 소셜 연결 해제 (Kakao `unlink` / Apple `revoke`) — 실패해도 로그만 남기고 탈퇴는 계속 진행
+2. `correction_segments` → `feedbacks` → `letters` → `terms_agreements` → `users` 순서로 삭제
+
+#### `실패` Error Response
+
+```json
+{
+    "status": 404,
+    "code": "USER_001",
+    "message": "사용자를 찾을 수 없습니다."
+}
+```
+
+---
+
+### 3.5 `PATCH /api/v1/users/nickname`
+
+> **API 설명**
+> - 닉네임을 등록하거나 변경합니다.
+> - 온보딩(이름 입력)과 설정(이름 변경)이 동일한 API 를 사용합니다.
+
+#### Request
+
+**Endpoint**
+
+```
+/api/v1/users/nickname
+```
+
+**Authorization 헤더**
+
+```
+Bearer eyJhbGciOiJIUzI1NiJ9...
+```
+
+**Body**
+
+```json
+{
+    "nickname": "iloveJolly"
+}
+```
+
+- [필수] `nickname` (String): 변경할 닉네임 (영문 + 숫자, 1~20자)
+
+**검증 규칙**
+
+| 규칙 | 값 | code |
+| --- | --- | --- |
+| 길이 | 1 ~ 20자 (문자 수) | `USER_004` |
+| 허용 문자 | `^[A-Za-z0-9]{1,20}$` | `USER_003` |
+| 공백 · 특수기호 · 한글 | 불가 | `USER_003` |
+
+- 앱은 사유별 문구(`공백을 포함할 수 없어요` / `특수 기호를 포함할 수 없어요` / `한글을 포함할 수 없어요`)를 클라이언트에서 판별해 표시한다. 서버는 최종 방어선이다.
+- 닉네임 **중복은 허용**한다 (표시용 이름).
+
+#### `성공` Response 200
+
+```json
+{
+    "nickname": "iloveJolly"
+}
+```
+
+- [필수] `nickname` (String): 변경된 닉네임
+
+#### `실패` Error Response
+
+```json
+{
+    "status": 400,
+    "code": "USER_003",
+    "message": "닉네임은 공백, 특수기호, 한글 없이 작성해야 합니다."
+}
+```
+
+---
+
+## 4. letter
+
+### 4.1 `POST /api/v1/letter`
+
+> **API 설명**
+> - 새로운 편지를 작성합니다.
+> - 편지가 저장되면 AI 피드백 프로세스가 트리거됩니다.
+
+#### Request
+
+**Endpoint**
+
+```
+/api/v1/letter
+```
+
+**Authorization 헤더**
+
+```
+Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3MzEyMjg1ODIsImV4cCI6MTczMTIyODYxOH0.ZCvhG9hWexsMg-dpJrtFQBpYbXIwmWgZrYk6AlugQVU
+```
+
+**Body**
+
+```json
+{
+    "content": "I got flowers from a friend today...",
+    "letterDate": "2025-11-01"
+}
+```
+
+- [필수] `content` (String): 편지 내용 (최대 500자)
+- [필수] `letterDate` (LocalDate): 일기 날짜 (`YYYY-MM-DD`)
+
+**검증 규칙**
+
+| 규칙 | 상세 | code |
+| --- | --- | --- |
+| 필수 | `null` / 공백만 있는 값 불가 | `LETTER_001` |
+| 길이 | 1 ~ 500자 (문자 수, 공백 포함) | `LETTER_003` |
+| 언어 | `[가-힣ㄱ-ㅎㅏ-ㅣ]` 포함 시 거부 | `LETTER_004` |
+| 날짜 | 서버 KST 기준 **오늘**이어야 함 ([Q2](#8-확인-필요-항목)) | `LETTER_005` |
+
+- 편지 작성 화면의 `DATE:` 는 터치 · 변경이 불가하므로 `letterDate` 는 항상 오늘 날짜가 들어온다. 서버는 이를 검증한다.
+- 편지는 전달 후 **수정 · 삭제 불가**다.
+- 피드백은 **비동기 처리**되며, 이 API 는 LLM 응답을 기다리지 않고 즉시 반환한다.
+
+#### `성공` Response 200
+
+```json
+{
+    "letterId": 16,
+    "createdAt": "2025-11-01T21:00:00"
+}
+```
+
+- [필수] `letterId` (Long): 편지 ID
+- [필수] `createdAt` (LocalDateTime): 저장시각
+
+#### `실패` Error Response
+
+```json
+{
+    "status": 400,
+    "code": "LETTER_001",
+    "message": "편지 내용은 null일 수 없습니다."
+}
+```
+
+| code | status | 상황 |
+| --- | --- | --- |
+| `LETTER_001` | 400 | `content` 가 `null` / 빈 값 |
+| `LETTER_003` | 400 | 500자 초과 |
+| `LETTER_004` | 400 | 한글 포함 |
+| `LETTER_005` | 400 | `letterDate` 가 오늘이 아님 |
+
+---
+
+### 4.2 `GET /api/v1/letters/{letterId}`
+
+> **API 설명**
+> - 특정 편지의 상세 내용과 도착한 피드백(교정문, 팁 등)을 조회합니다.
+
+#### Request
+
+**Endpoint**
+
+```
+/api/v1/letters/{letterId}
+```
+
+**Authorization 헤더**
+
+```
+Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3MzEyMjg1ODIsImV4cCI6MTczMTIyODYxOH0.ZCvhG9hWexsMg-dpJrtFQBpYbXIwmWgZrYk6AlugQVU
+```
+
+**Path Variable**
+
+- [필수] `letterId`: 조회할 편지의 ID
+
+#### `성공` Response 200
+
+```json
+{
+    "letterId": 15,
+    "date": "2025-11-01",
+    "originalContent": "I got flowers from a friend today...",
+    "status": "FEEDBACK_COMPLETED",
+    "feedback": {
+        "feedbackId": 101,
+        "correctedContent": "I received flowers from a friend today...",
+        "tips": [
+            "이 문맥에서는 'got'보다 'received'가 더 자연스러워요.",
+            "'that'은 선행사를 한정하는 필수 정보를, 'which'는 추가 정보를 제공하는 데 쓰여요!"
+        ],
+        "correctionSegments": [
+            {
+                "sequence": 1,
+                "originalText": "I ",
+                "correctedText": "I ",
+                "type": "UNCHANGED"
+            },
+            {
+                "sequence": 2,
+                "originalText": "got",
+                "correctedText": "received",
+                "type": "MODIFIED"
+            },
+            {
+                "sequence": 3,
+                "originalText": " flowers from a friend today",
+                "correctedText": " flowers from a friend today",
+                "type": "UNCHANGED"
+            }
+        ]
+    }
+}
+```
+
+- [필수] `letterId` (Long): 편지 ID
+- [필수] `date` (LocalDate): 작성 날짜 (`yyyy-MM-dd`)
+- [필수] `originalContent` (String): 원본 편지 내용
+- [필수] `status` (String): 편지 상태 (`SUBMITTED`, `FEEDBACK_COMPLETED`) — [Q1](#8-확인-필요-항목)
+- [선택] `feedback` (Object): 피드백 정보 (**피드백 생성 전일 경우 `null`**)
+    - [필수] `feedbackId` (Long): 피드백 ID
+    - [필수] `correctedContent` (String): 교정된 전체 내용
+    - [필수] `tips` (Array&lt;String&gt;): 피드백 팁 목록 (0~3개, 없으면 `[]`) — [Q3](#8-확인-필요-항목)
+    - [필수] `correctionSegments` (Array): 교정 세그먼트 리스트
+        - [필수] `sequence` (Integer): 문장 내 순서 (1부터 시작)
+        - [필수] `originalText` (String): 원본 텍스트 조각
+        - [필수] `correctedText` (String): 교정된 텍스트 조각
+        - [필수] `type` (String): 수정 여부 (`UNCHANGED`, `MODIFIED`)
+
+**렌더링 계약**
+
+- `correctionSegments` 를 `sequence` 순서대로 이어붙이면 **`originalText` 는 원문 전체**, **`correctedText` 는 `correctedContent` 전체**와 정확히 일치한다. 앱은 별도 인덱스 계산 없이 순차 렌더링만 하면 된다.
+- `type == "UNCHANGED"` → 검은 글씨 그대로 출력
+- `type == "MODIFIED"` → `originalText` 를 빨간 취소선, 바로 뒤에 `correctedText` 를 초록 하이라이트로 출력
+- 공백은 세그먼트 문자열에 포함해 내려준다 (앱에서 공백을 임의로 추가하지 않음).
+- 삭제 제안은 `type == "MODIFIED"` + `correctedText == ""` 로 표현한다.
+
+#### `실패` Error Response
+
+```json
+{
+    "status": 404,
+    "code": "LETTER_002",
+    "message": "존재하지 않는 편지입니다."
+}
+```
+
+| code | status | 상황 |
+| --- | --- | --- |
+| `LETTER_002` | 404 | 존재하지 않는 편지 **또는 타인의 편지** (존재 여부를 노출하지 않기 위해 403 대신 404) |
+
+**부수 효과**: 조회 성공 시 해당 편지를 **읽음 처리(`isRead = true`)** 한다. 별도의 읽음 처리 API 는 두지 않는다.
+
+---
+
+### 4.3 `GET /api/v1/letters`
+
+> **API 설명**
+> - 홈 화면에 진입했을 때 보여질 편지 리스트를 조회합니다.
+
+#### Request
+
+**Endpoint**
+
+```
+/api/v1/letters
+```
+
+**Authorization 헤더**
+
+```
+Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3MzEyMjg1ODIsImV4cCI6MTczMTIyODYxOH0.ZCvhG9hWexsMg-dpJrtFQBpYbXIwmWgZrYk6AlugQVU
+```
+
+**Query Parameter**
+
+- [선택] `page`: 페이지 번호 (기본값 0)
+- [선택] `size`: 페이지 크기 (기본값 10)
+- [선택] `sort`: 정렬 기준 (`LATEST` 기본값, `OLDEST`) — 홈 화면의 `최신순 / 오래된 순` 토글용 ([Q4](#8-확인-필요-항목))
+
+#### `성공` Response 200
+
+```json
+{
+    "nickname": "Sally",
+    "totalStampCount": 3,
+    "letters": [
+        {
+            "letterId": 15,
+            "date": "2025-11-01",
+            "summary": "I got flowers from a friend today. It really ...",
+            "status": "FEEDBACK_COMPLETED",
+            "isRead": false,
+            "stampImage": "https://s3.../flower_stamp.png"
+        },
+        {
+            "letterId": 12,
+            "date": "2025-10-30",
+            "summary": "Hi! Jolly. I made a new friend at a Halloween ...",
+            "status": "FEEDBACK_COMPLETED",
+            "isRead": true,
+            "stampImage": "https://s3.../pumpkin_stamp.png"
+        }
+    ],
+    "hasNext": true
+}
+```
+
+- [필수] `nickname` (String): 유저 닉네임
+- [필수] `totalStampCount` (Integer): 모은 우표 총 개수
+- [필수] `letters` (Array): 편지 목록
+    - [필수] `letterId` (Long): 편지 ID
+    - [필수] `date` (LocalDate): 작성 날짜 (`yyyy-MM-dd`)
+    - [필수] `summary` (String): 편지 내용 요약 (목록 노출용, 원문 앞 30자)
+    - [필수] `status` (String): 편지 상태
+        - `SUBMITTED`: 제출됨 (피드백 대기중)
+        - `FEEDBACK_COMPLETED`: 피드백 완료
+    - [필수] `isRead` (Boolean): 피드백 확인 여부 (`false`면 NEW 뱃지 노출)
+    - [선택] `stampImage` (String): 우표 이미지 URL (피드백 완료 전에는 `null`)
+- [필수] `hasNext` (Boolean): 다음 페이지 존재 여부
+
+**클라이언트 렌더링 규칙**
+
+| 조건 | 표시 |
+| --- | --- |
+| `status != FEEDBACK_COMPLETED` | 회색 `soon` 우표, `ic_more_sm` 미노출, **터치 불가** |
+| `status == FEEDBACK_COMPLETED` | `stampImage` 표시, `ic_more_sm` 노출, **카드 전체 영역** 터치 시 상세 이동 |
+| `status == FEEDBACK_COMPLETED && isRead == false` | 날짜 앞 빨간 점 |
+
+- `totalStampCount` 는 **작성한 편지 수가 아니라** 피드백이 완료되어 우표가 도착한 편지 수다. (편지 3건 작성 + 1건 피드백 대기 → `totalStampCount = 2`)
+- `SUBMITTED` 항목이 있으면 앱이 화면 재진입 · 새로고침 시 재조회해 상태 변화를 확인한다 (폴링 전용 API 없음).
+
+#### `실패` Error Response
+
+```json
+{
+    "status": 404,
+    "code": "USER_001",
+    "message": "사용자를 찾을 수 없습니다."
+}
+```
+
+---
+
+### 4.4 `GET /api/v1/home`
+
+> **API 설명**
+> - 홈 화면에 진입했을 때 보여질 유저 정보(닉네임, 모은 우표 수)를 조회합니다.
+
+#### Request
+
+**Endpoint**
+
+```
+/api/v1/home
+```
+
+**Authorization 헤더**
+
+```
+Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImV1bmplb25nIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3MzEyMjg1ODIsImV4cCI6MTczMTIyODYxOH0.ZCvhG9hWexsMg-dpJrtFQBpYbXIwmWgZrYk6AlugQVU
+```
+
+**Query Parameter**: 없음
+
+#### `성공` Response 200
+
+```json
+{
+    "nickname": "Sally",
+    "totalStampCount": 3
+}
+```
+
+- [필수] `nickname` (String): 유저 닉네임
+- [필수] `totalStampCount` (Integer): 모은 우표 총 개수 (피드백 완료된 편지 수)
+
+#### `실패` Error Response
+
+```json
+{
+    "status": 404,
+    "code": "USER_001",
+    "message": "사용자를 찾을 수 없습니다."
+}
+```
+
+> ⚠️ 초안에서 이 API 의 Endpoint 가 `/api/v1/letters` 로, Response 가 편지 리스트 응답으로 복사되어 있었다. 위 내용으로 정정했다. `/api/v1/letters` 와 응답 필드가 중복되는 문제는 [Q5](#8-확인-필요-항목) 참고.
+
+---
+
+## 5. version
+
+### 5.1 `GET /api/v1/version`
+
+> **API 설명**
+> - 앱 최소 지원 버전과 정책 페이지 URL 을 조회합니다.
+
+#### Request
+
+**Endpoint**
+
+```
+/api/v1/version
+```
+
+**Authorization 헤더**: 불필요
+
+**Query Parameter**
+
+- [선택] `platform`: 플랫폼 (`IOS`, `AOS`). 생략 시 공통 값 반환
+
+#### `성공` Response 200
+
+```json
+{
+    "latestVersion": "1.0.0",
+    "minSupportedVersion": "1.0.0",
+    "forceUpdate": false,
+    "privacyPolicyUrl": "https://dearjolly.com/privacy",
+    "termsOfServiceUrl": "https://dearjolly.com/terms",
+    "noticeUrl": "https://dearjolly.com/notice"
+}
+```
+
+- [필수] `latestVersion` (String): 최신 배포 버전
+- [필수] `minSupportedVersion` (String): 이 버전 미만이면 강제 업데이트
+- [필수] `forceUpdate` (Boolean): 강제 업데이트 여부
+- [선택] `privacyPolicyUrl` (String): 개인정보처리방침 URL
+- [선택] `termsOfServiceUrl` (String): 서비스 이용약관 URL
+- [선택] `noticeUrl` (String): 공지사항 URL
+
+- 설정 화면의 `현재 버전 1.0.0 (MVP)` 는 앱 로컬 값이고, 이 API 는 업데이트 유도 · 정책 링크 제공용이다.
+- 공지사항 · 개인정보처리방침은 별도 API 없이 **웹뷰 링크**로 처리한다.
+
+---
+
+## 6. Enum 정의
+
+| Enum | 값 | 비고 |
+| --- | --- | --- |
+| `Provider` | `KAKAO`, `APPLE` | |
+| `TermsType` | `SERVICE`, `PRIVACY`, `MARKETING` | `MARKETING` 만 선택 동의 |
+| `Status` (letter) | `SUBMITTED`, `FEEDBACK_COMPLETED` | 내부 상태 `FEEDBACK_FAILED` 는 앱에 `SUBMITTED` 로 내려보냄 — [Q1](#8-확인-필요-항목) |
+| `SegmentType` | `UNCHANGED`, `MODIFIED` | |
+| `Sort` | `LATEST`, `OLDEST` | |
+
+---
+
+## 7. 에러 코드
+
+### 7.1 AUTH
+
+| code | status | message |
+| --- | --- | --- |
+| `AUTH_001` | 400 | 지원하지 않는 로그인 방식입니다. |
+| `AUTH_002` | 401 | 소셜 로그인 인증에 실패했습니다. |
+| `AUTH_003` | 502 | 소셜 로그인 서버와 통신하지 못했습니다. |
+| `AUTH_004` | 401 | 만료된 토큰입니다. |
+| `AUTH_005` | 401 | 유효하지 않은 토큰입니다. |
+| `AUTH_006` | 403 | 접근 권한이 없습니다. |
+
+### 7.2 USER
+
+| code | status | message |
+| --- | --- | --- |
+| `USER_001` | 404 | 사용자를 찾을 수 없습니다. |
+| `USER_002` | 400 | 필수 약관에 모두 동의해야 합니다. |
+| `USER_003` | 400 | 닉네임은 공백, 특수기호, 한글 없이 작성해야 합니다. |
+| `USER_004` | 400 | 닉네임은 1자 이상 20자 이하여야 합니다. |
+| `USER_005` | 400 | 온보딩을 먼저 완료해야 합니다. |
+
+### 7.3 LETTER
+
+| code | status | message |
+| --- | --- | --- |
+| `LETTER_001` | 400 | 편지 내용은 null일 수 없습니다. |
+| `LETTER_002` | 404 | 존재하지 않는 편지입니다. |
+| `LETTER_003` | 400 | 편지 내용은 500자를 초과할 수 없습니다. |
+| `LETTER_004` | 400 | 편지는 영어로만 작성할 수 있습니다. |
+| `LETTER_005` | 400 | 편지 날짜가 올바르지 않습니다. |
+
+### 7.4 COMMON
+
+| code | status | message |
+| --- | --- | --- |
+| `COMMON_001` | 400 | 잘못된 요청입니다. |
+| `COMMON_002` | 404 | 요청하신 경로를 찾을 수 없습니다. |
+| `COMMON_003` | 405 | 지원하지 않는 요청 방식입니다. |
+| `COMMON_004` | 429 | 요청이 너무 많습니다. 잠시 후 다시 시도해주세요. |
+| `COMMON_005` | 500 | 일시적인 오류가 발생했습니다. |
+
+---
+
+## 8. 확인 필요 항목
+
+초안 검토 중 발견한 충돌 · 결정 필요 사항. **구현 착수 전 확정 필요**.
+
+### Q1. `status` enum 값이 초안 내에서 충돌한다 ⚠️
+
+- JSON 예시: `"status": "FEEDBACK_COMPLETED"`
+- 필드 설명: `DRAFT`(작성중), `SUBMITTED`(제출됨), `ANALYZED`(피드백완료)
+
+→ 같은 필드에 두 가지 값 체계가 섞여 있다. **본 문서는 JSON 예시를 따라 `FEEDBACK_COMPLETED` 로 통일**했다.
+
+추가로, MVP 에는 **임시저장 기능이 없고**(작성 → 전달하기 → 수정 불가) 편지는 생성 즉시 피드백이 트리거되므로 `DRAFT` 는 사용되지 않는다. 제안하는 최종 값:
+
+| 값 | 의미 | 앱 표시 |
+| --- | --- | --- |
+| `SUBMITTED` | 제출됨, 피드백 대기 | 회색 `soon` 우표 |
+| `FEEDBACK_COMPLETED` | 피드백 완료 | 우표 노출, 상세 진입 가능 |
+| `FEEDBACK_FAILED` | (내부용) 피드백 실패 | 앱에는 `SUBMITTED` 로 내려 실패를 노출하지 않음 |
+
+### Q2. `letterDate` 를 클라이언트가 보내는 게 맞는가?
+
+작성 화면의 `DATE:` 는 **터치 · 변경이 불가**하다(기획 주석). 즉 항상 오늘 날짜다.
+
+- **권장**: 요청 필드는 유지하되 **서버가 KST 기준 오늘과 일치하는지 검증**(`LETTER_005`)한다. 과거/미래 날짜로 기록을 조작할 수 없게 된다.
+- 대안: 필드를 아예 받지 않고 서버 시각으로 설정. 단, 자정 근처에서 앱 표시 날짜와 어긋날 수 있다.
+
+### Q3. `tip` 이 단일 String 이면 디자인을 구현할 수 없다 ⚠️
+
+디자인에 **`검토하기-팁없음` / `팁단일` / `팁여러개`** 세 가지 상태가 있고, 팁여러개 시안은 팁 카드가 2개 분리되어 있다.
+
+- 초안: `tip` (String)
+- **본 문서: `tips` (Array&lt;String&gt;)** 로 변경 — 0개면 `[]`(팁 영역 미표시), n개면 카드 n개
+
+단일 String 을 유지하면 앱이 개행 기준으로 쪼개야 해서 취약하다.
+
+### Q4. 정렬 파라미터가 초안에 없다
+
+홈 화면에 `최신순 / 오래된 순` 토글이 있다. `sort` 쿼리 파라미터를 추가했다. 클라이언트 정렬로 처리할 경우 페이징과 충돌하므로 **서버 정렬 권장**.
+
+### Q5. `/api/v1/letters` 와 `/api/v1/home` 의 응답이 중복된다
+
+초안에서는 `/letters` 응답에도 `nickname`, `totalStampCount` 가 포함되어 있다. 두 가지 선택지:
+
+| 안 | 내용 | 장단점 |
+| --- | --- | --- |
+| **A (현재 문서)** | `/letters` 에 헤더 정보 포함 + `/home` 도 유지 | 홈 진입 시 **1회 호출**로 끝남. `/home` 은 위젯 등 확장용으로 남김 |
+| B | `/letters` 는 목록만, `/home` 은 헤더만 | 책임 분리는 깔끔하나 홈 진입 시 항상 2회 호출 |
+
+→ 화면 성능상 **A 권장**. B 로 간다면 `/letters` 응답에서 `nickname`, `totalStampCount` 를 제거해야 한다.
+
+### Q6. 토큰 재발급 · 로그아웃 API 가 없다 ⚠️
+
+- **재발급**: Access Token 만료가 30분이므로 `POST /api/v1/auth/reissue` 가 없으면 30분마다 재로그인해야 한다. **MVP 필수로 판단**.
+- **로그아웃**: 설정 화면에 버튼이 있다. 서버에서 Refresh Token 을 무효화하려면 `POST /api/v1/auth/logout` 이 필요하고, 클라이언트 토큰 폐기만으로 처리한다면 API 는 불필요하다.
+
+### Q7. 기타
+
+| 항목 | 내용 |
+| --- | --- |
+| `POST /letter` 응답 코드 | 초안은 `200`. REST 관례상 `201 Created` 이나, **초안대로 200 유지**했다 |
+| `/letter` vs `/letters` | 생성만 단수라 혼동 여지가 있다. `POST /api/v1/letters` 통일 검토 |
+| `summary` 길이 | 원문 앞 **30자**로 가정했다. 디자인 확정 시 조정 필요 |
+| `stampImage` | S3 URL 방식이면 CDN 캐싱 헤더 설정 필요. 앱 로컬 리소스(enum) 방식 대비 네트워크 비용이 있다 |
+| 하루 작성 개수 제한 | 현재 명세는 **제한 없음**. 하루 1통 제한 시 `LETTER_006` 추가 필요 |

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -1,0 +1,563 @@
+# Dear Jolly — ERD (데이터 모델)
+
+> 이 문서는 Dear Jolly 서버 데이터 모델의 **정본**이다. 스키마에 관한 모든 판단은 이 문서를 따른다.
+> 도메인 규칙 배경은 [기능명세.md](./기능명세.md), 요청/응답 계약은 [API명세.md](./API명세.md) 참고.
+
+| 항목 | 내용 |
+| --- | --- |
+| 최종 갱신 | 2026-08-22 |
+| DBMS | MySQL 8.x / `utf8mb4` · `utf8mb4_0900_ai_ci` |
+| 스키마 관리 | **Flyway** 로 형상 관리. JPA 는 전 환경 `ddl-auto: validate` 로 검증만 수행 |
+| ID 전략 | 전 테이블 `GenerationType.IDENTITY` (`BIGINT AUTO_INCREMENT`) |
+| Enum 저장 | 전부 `EnumType.STRING` (문자열 저장) |
+| 시각 컬럼 | `DATETIME(6)`. `@PrePersist` / `@PreUpdate` 로 주입. 서버 TZ `Asia/Seoul` |
+| 날짜 컬럼 | `DATE`. **요청에 담긴 클라이언트 타임존 기준**으로 환산해 저장한다 (§5.2 A3) |
+
+---
+
+## 목차
+
+1. [ER 다이어그램](#1-er-다이어그램)
+2. [테이블 정의](#2-테이블-정의)
+3. [연관관계](#3-연관관계)
+4. [Enum 정의](#4-enum-정의)
+5. [제약 조건](#5-제약-조건)
+6. [데이터 수명주기](#6-데이터-수명주기)
+7. [부록: DDL](#7-부록-ddl)
+
+---
+
+## 1. ER 다이어그램
+
+```mermaid
+erDiagram
+    USERS ||--o{ TERMS_AGREEMENTS : "agrees"
+    USERS ||--o{ LETTERS : "writes"
+    LETTERS ||--o| FEEDBACKS : "has"
+    FEEDBACKS ||--|{ CORRECTION_SEGMENTS : "splits into"
+    FEEDBACKS ||--o{ FEEDBACK_TIPS : "contains"
+    STAMPS ||--o{ LETTERS : "granted to"
+
+    USERS {
+        BIGINT user_id PK "사용자 식별자"
+        VARCHAR_10 oauth_provider UK "소셜 로그인 제공자 (OauthProvider)"
+        VARCHAR_255 oauth_id UK "provider 가 발급한 회원 식별자"
+        VARCHAR_255 email "설정 화면 노출용 이메일 (미제공 시 NULL)"
+        VARCHAR_20 nickname "표시용 닉네임 (온보딩 전 NULL, 중복 허용)"
+        VARCHAR_20 role "권한 (Role)"
+        VARCHAR_20 status "계정 상태 (UserStatus)"
+        VARCHAR_500 refresh_token "최신 리프레시 토큰 1개"
+        DATETIME created_at "가입 시각"
+        DATETIME updated_at "마지막 수정 시각"
+        DATETIME deleted_at "탈퇴 시각 (soft delete)"
+    }
+
+    TERMS_AGREEMENTS {
+        BIGINT terms_agreement_id PK "동의 이력 식별자"
+        BIGINT user_id FK "동의한 사용자"
+        VARCHAR_20 type "약관 종류 (TermsType)"
+        BOOLEAN agreed "동의 여부"
+        VARCHAR_20 terms_version "동의 시점의 약관 버전"
+        DATETIME agreed_at "동의·철회 시각"
+    }
+
+    LETTERS {
+        BIGINT letter_id PK "편지 식별자"
+        BIGINT user_id FK "작성자"
+        VARCHAR_500 content "편지 원문 (영어 1~500자)"
+        DATE letter_date "요청 타임존 기준 작성 날짜"
+        VARCHAR_30 status "피드백 진행 상태 (Status)"
+        BIGINT stamp_id FK "피드백 완료 시 부여되는 우표"
+        BOOLEAN is_read "피드백 열람 여부"
+        INT retry_count "피드백 재시도 횟수"
+        DATETIME created_at "작성 시각"
+        DATETIME updated_at "상태 전이 시각 (유실 판별 기준)"
+    }
+
+    STAMPS {
+        BIGINT stamp_id PK "우표 식별자"
+        VARCHAR_30 name UK "우표 한글 이름 (AI 선택 키)"
+        VARCHAR_100 description "한 줄 한글 설명"
+        VARCHAR_500 image_url "우표 이미지 URL"
+        BOOLEAN is_active "선택 후보 노출 여부"
+    }
+
+    FEEDBACKS {
+        BIGINT feedback_id PK "피드백 식별자"
+        BIGINT letter_id FK,UK "대상 편지 (편지당 1건)"
+        VARCHAR_1000 corrected_content "교정이 모두 반영된 전체 문장"
+        VARCHAR_50 model "사용한 LLM 모델 ID"
+        DATETIME created_at "피드백 생성 시각"
+    }
+
+    CORRECTION_SEGMENTS {
+        BIGINT correction_segment_id PK "교정 조각 식별자"
+        BIGINT feedback_id FK,UK "소속 피드백"
+        INT sequence UK "조각 순서 (1부터 연속)"
+        VARCHAR_500 original_text "원본 텍스트 조각"
+        VARCHAR_500 corrected_text "교정 텍스트 조각 (삭제면 빈 문자열)"
+        VARCHAR_20 correction_type "교정 여부 구분 (CorrectionType)"
+    }
+
+    FEEDBACK_TIPS {
+        BIGINT feedback_tip_id PK "팁 식별자"
+        BIGINT feedback_id FK,UK "소속 피드백"
+        INT sort_order UK "표시 순서 (1부터 연속)"
+        VARCHAR_500 content "한국어 학습 팁 문장"
+    }
+```
+
+> 각 컬럼의 맨 우측 열은 **한글 설명**이다. 제약(NOT NULL · DEFAULT · UNIQUE 등)과 컬럼별 상세는 [2. 테이블 정의](#2-테이블-정의) 의 `제약` 열을 참고한다.
+
+### 카디널리티
+
+| 관계 | 카디널리티 | 의미 |
+| --- | --- | --- |
+| `USERS` → `TERMS_AGREEMENTS` | 1 : 0..N | 약관 동의는 이력으로 누적된다. 가입 직후에는 0행이고, 온보딩을 마치면 최소 3행이 쌓인다 |
+| `USERS` → `LETTERS` | 1 : 0..N | 한 유저가 편지를 여러 통 작성한다 |
+| `LETTERS` → `FEEDBACKS` | 1 : 0..1 | 편지 한 통당 피드백은 최대 1건이다 |
+| `FEEDBACKS` → `CORRECTION_SEGMENTS` | 1 : 1..N | 피드백은 원문을 나눈 교정 조각을 순서대로 가진다 |
+| `FEEDBACKS` → `FEEDBACK_TIPS` | 1 : 0..3 | 피드백은 학습 팁을 최대 3개까지 가진다 |
+
+---
+
+## 2. 테이블 정의
+
+### 2.1 `USERS` — 사용자
+
+| 컬럼 | 타입 | 제약 | 설명 |
+| --- | --- | --- | --- |
+| `user_id` | BIGINT | PK, AUTO_INCREMENT | |
+| `oauth_provider` | VARCHAR(10) | NOT NULL | `KAKAO` / `APPLE` |
+| `oauth_id` | VARCHAR(255) | NOT NULL | provider 가 발급한 회원 식별자 (Kakao `id`, Apple `sub`) |
+| `email` | VARCHAR(255) | NULL | 설정 화면 노출용. Apple private relay 거부 등으로 provider 가 주지 않으면 NULL 이다. 서버가 대체 주소를 지어내지 않는다 |
+| `nickname` | VARCHAR(20) | NULL | 1~20자, 영문·숫자만. **가입 시점에는 NULL** 이고 온보딩에서 채운다. 중복을 허용한다 |
+| `role` | VARCHAR(20) | NOT NULL | `ROLE_USER` / `ROLE_ADMIN` |
+| `status` | VARCHAR(20) | NOT NULL | `ACTIVE` / `WITHDRAWN` |
+| `refresh_token` | VARCHAR(500) | NULL | 최신 refresh token 1개만 보관한다 (단일 세션 정책). 로그아웃·탈퇴 시 NULL |
+| `created_at` | DATETIME(6) | NOT NULL | 가입 시각 |
+| `updated_at` | DATETIME(6) | NOT NULL | 마지막 수정 시각 |
+| `deleted_at` | DATETIME(6) | NULL | 탈퇴 시각. `status = WITHDRAWN` 일 때만 값이 있다 |
+
+- UNIQUE `(oauth_provider, oauth_id)` — 소셜 계정당 1계정.
+- 로그인 시 회원 조회 키는 `(oauth_provider, oauth_id)` 다. `email` 은 표시용이며 provider 가 다르면 같은 주소가 존재할 수 있다.
+- 닉네임은 중복을 허용한다. 표시용 이름이며 식별자로 쓰지 않는다.
+- **온보딩 완료 여부는 별도 컬럼 없이 파생한다.** 약관 동의 여부는 `TERMS_AGREEMENTS` 조회로, 닉네임 등록 여부는 `nickname IS NOT NULL` 로 판별한다.
+- `email` · `nickname` 이 NULL 일 수 있으므로 응답 DTO 에서도 nullable 이다 (API명세 §3.5).
+
+### 2.2 `TERMS_AGREEMENTS` — 약관 동의 이력
+
+약관 동의를 **행으로 누적**한다. 개인정보보호법상 "언제, 어느 버전에, 무엇에 동의했는가"를 사후에 입증할 수 있어야 하므로 값을 덮어쓰지 않는다.
+
+| 컬럼 | 타입 | 제약 | 설명 |
+| --- | --- | --- | --- |
+| `terms_agreement_id` | BIGINT | PK, AUTO_INCREMENT | |
+| `user_id` | BIGINT | FK → `USERS.user_id`, NOT NULL | 동의한 사용자 |
+| `type` | VARCHAR(20) | NOT NULL | `SERVICE` / `PRIVACY` / `MARKETING` |
+| `agreed` | BOOLEAN | NOT NULL | 동의 `true` / 미동의·철회 `false` |
+| `terms_version` | VARCHAR(20) | NOT NULL | 동의 시점의 약관 버전. 서버 설정값 `dearjolly.terms.current-version` 을 그대로 기록한다 |
+| `agreed_at` | DATETIME(6) | NOT NULL | 동의·철회 시각. **서버 시각(KST)** 으로 기록한다 |
+
+- INDEX `(user_id, type, agreed_at DESC)` — 항목별 최신 행 조회.
+- **현재 동의 상태 = `(user_id, type)` 별 `agreed_at` 이 가장 최신인 행의 `agreed`** 다. UNIQUE 제약을 두지 않는 이유가 이것이다.
+- `POST /api/v1/users/terms` 는 요청에 담긴 항목마다 **행을 새로 INSERT** 한다. UPDATE 하지 않는다.
+- `terms_version` 은 **기록·입증 목적**이다. 약관이 개정돼도 기존 유저에게 재동의를 요구하지 않으며, `termsAgreed` 판별에 버전을 쓰지 않는다. 재동의 유도는 MVP 범위 밖이다 (기능명세 §7).
+- 마케팅 동의를 철회하면 `agreed = false` 인 행이 하나 더 쌓인다. 이전 동의 이력은 그대로 남는다.
+- 필수 약관(`SERVICE` · `PRIVACY`)에 동의하기 전까지 유저는 온보딩 미완료 상태이며, 본 기능 API 접근이 차단된다 (`USER_005`).
+
+### 2.3 `LETTERS` — 편지
+
+| 컬럼 | 타입 | 제약 | 설명 |
+| --- | --- | --- | --- |
+| `letter_id` | BIGINT | PK, AUTO_INCREMENT | API 의 `letterId` |
+| `user_id` | BIGINT | FK → `USERS.user_id`, NOT NULL | 작성자 |
+| `content` | VARCHAR(500) | NOT NULL | 편지 원문. 영어 전용, 1~500자 (R2). API 의 `originalContent` |
+| `letter_date` | DATE | NOT NULL | 요청의 `writtenAt` 을 `timeZone` 기준으로 환산한 날짜 (R9). API 의 `date`. 목록 정렬·표시 기준 |
+| `status` | VARCHAR(30) | NOT NULL | `SUBMITTED` / `FEEDBACK_IN_PROGRESS` / `FEEDBACK_COMPLETED` / `FEEDBACK_FAILED` |
+| `stamp_id` | BIGINT | FK → `STAMPS.stamp_id`, NULL | `FEEDBACK_COMPLETED` 전이 시 부여한다. 그 전에는 NULL |
+| `is_read` | BOOLEAN | NOT NULL, DEFAULT `false` | 피드백 열람 여부 (R6). 상세 조회 시 `true` 로 전환 |
+| `retry_count` | INT | NOT NULL, DEFAULT `0` | 피드백 재시도 횟수. 3회 초과 시 `FEEDBACK_FAILED` |
+| `created_at` | DATETIME(6) | NOT NULL | 서버 저장 시각(KST). 응답의 `createdAt` 은 이 값을 요청 타임존으로 변환해 내려준다 |
+| `updated_at` | DATETIME(6) | NOT NULL | 상태 전이 시각. 이벤트 유실·처리 유실 판별의 기준이다 |
+
+- INDEX `(user_id, letter_date DESC, letter_id DESC)` — 목록 정렬·페이징.
+- INDEX `(status, updated_at)` — 미처리 편지 스캔 배치. `SUBMITTED` 이벤트 유실(1시간 초과)과 `FEEDBACK_IN_PROGRESS` 처리 유실(15분 초과)을 이 인덱스로 찾는다 (기능명세 §3.5.1).
+- 워커 픽업은 `UPDATE letters SET status = 'FEEDBACK_IN_PROGRESS' WHERE letter_id = ? AND status = 'SUBMITTED'` 조건부 UPDATE 로 수행한다. 갱신 건수 0이면 다른 워커가 이미 집은 것이므로 처리를 건너뛴다.
+- 편지는 append-only 다 (R1). 등록 후 `content` 와 `letter_date` 는 변경되지 않으며, 사용자 요청으로 삭제되지도 않는다. 변경되는 컬럼은 `status` · `stamp_id` · `is_read` · `retry_count` · `updated_at` 뿐이다.
+- 우표 카운트(R4)는 `status = 'FEEDBACK_COMPLETED'` 인 행 수로 계산한다.
+- **재시도 백오프 상태는 DB 에 두지 않는다.** 워커가 인메모리 `TaskScheduler` 로 재호출을 예약하며, 예약이 유실된 경우에만 보완 스케줄러가 `updated_at` 기준으로 주워 담는다.
+
+### 2.4 `STAMPS` — 우표 마스터
+
+피드백 완료 시 편지에 부여하는 우표의 마스터 데이터다. 우표 종류는 코드가 아니라 이 테이블의 행으로 관리하므로, 추가·교체·문구 수정에 배포가 필요 없다.
+
+| 컬럼 | 타입 | 제약 | 설명 |
+| --- | --- | --- | --- |
+| `stamp_id` | BIGINT | PK, AUTO_INCREMENT | |
+| `name` | VARCHAR(30) | NOT NULL, UNIQUE | 우표 한글 이름 (예: `장미`). LLM 이 고른 이름을 이 컬럼으로 조회해 행을 특정한다 |
+| `description` | VARCHAR(100) | NOT NULL | 한 줄 한글 설명. 우표의 분위기를 서술하며, LLM 프롬프트에 함께 넣는다 |
+| `image_url` | VARCHAR(500) | NOT NULL | 우표 이미지 URL. 응답의 `stampImage` 로 그대로 내려보낸다 |
+| `is_active` | BOOLEAN | NOT NULL, DEFAULT `true` | `false` 면 선택 후보에서 제외한다. 기존 편지에 부여된 우표는 그대로 유지된다 |
+
+- `name` 이 UNIQUE 인 이유는 LLM 응답을 행으로 되돌리는 조회 키이기 때문이다.
+- 마스터 데이터이므로 삭제하지 않는다. 운영을 중단할 우표는 `is_active = false` 로 내린다. `LETTERS.stamp_id` 가 참조하는 행이 사라지지 않아야 하기 때문이다.
+- 이미지 교체는 `image_url` 갱신으로 처리한다. 앱 배포와 무관하다.
+- **우표 종류는 Java enum 으로 정의하지 않는다.** 코드에 우표 이름이 하드코딩되면 이 테이블의 존재 이유가 사라진다.
+
+#### 우표 부여 절차
+
+1. 피드백 워커가 `SELECT name, description FROM stamps WHERE is_active = true` 로 후보를 조회한다.
+2. 조회한 **한글 이름 목록과 설명을 프롬프트에 동적으로 삽입**하고, 편지 내용에 가장 어울리는 우표 이름 하나를 고르게 한다. 우표 종류가 늘거나 줄어도 프롬프트 템플릿은 그대로다.
+3. LLM 이 반환한 이름을 `name` 으로 조회해 `LETTERS.stamp_id` 에 채운다.
+4. 반환값이 후보 목록에 없으면 활성 우표 중 랜덤 1개로 대체한다. 우표 선택 실패가 피드백 저장 전체를 실패시키지 않는다.
+
+우표 부여는 `status = 'FEEDBACK_COMPLETED'` 전이와 동일한 트랜잭션에서 이뤄진다 (R3).
+
+### 2.5 `FEEDBACKS` — AI 피드백
+
+| 컬럼 | 타입 | 제약 | 설명 |
+| --- | --- | --- | --- |
+| `feedback_id` | BIGINT | PK, AUTO_INCREMENT | API 의 `feedbackId` |
+| `letter_id` | BIGINT | FK → `LETTERS.letter_id`, NOT NULL, UNIQUE | 편지 1 : 피드백 0..1 |
+| `corrected_content` | VARCHAR(1000) | NOT NULL | 교정이 모두 반영된 전체 문장 |
+| `model` | VARCHAR(50) | NOT NULL | 사용한 LLM 모델 ID. 재현·과금 추적용 |
+| `created_at` | DATETIME(6) | NOT NULL | |
+
+- 피드백 저장, 교정 조각·팁 저장, `LETTERS.status` 전이와 우표 부여는 **하나의 트랜잭션**에서 처리한다. 부분 저장 상태는 존재하지 않는다.
+- `corrected_content` 가 원문(500자)보다 긴 1000자인 이유는 교정으로 문장이 길어질 수 있기 때문이다.
+
+### 2.6 `CORRECTION_SEGMENTS` — 교정 조각
+
+원문을 `sequence` 순으로 잘게 나눈 조각이다. 순서대로 이어붙이면 원문과 교정문이 그대로 복원되므로, 앱은 인덱스 계산 없이 순차 렌더링만 한다.
+
+| 컬럼 | 타입 | 제약 | 설명 |
+| --- | --- | --- | --- |
+| `correction_segment_id` | BIGINT | PK, AUTO_INCREMENT | |
+| `feedback_id` | BIGINT | FK → `FEEDBACKS.feedback_id`, NOT NULL | |
+| `sequence` | INT | NOT NULL | 조각 순서. 1부터 연속 증가 |
+| `original_text` | VARCHAR(500) | NOT NULL | 원본 텍스트 조각 |
+| `corrected_text` | VARCHAR(500) | NOT NULL | 교정된 텍스트 조각. 삭제 제안이면 빈 문자열 |
+| `correction_type` | VARCHAR(20) | NOT NULL | `UNCHANGED` / `MODIFIED`. **API 응답에서는 `type` 이라는 이름으로 내려간다** |
+
+- UNIQUE `(feedback_id, sequence)`.
+- 조회 시 항상 `ORDER BY sequence ASC` 로 정렬한다 (`@OrderBy("sequence ASC")`).
+- 공백은 조각 문자열에 포함해 저장한다. 앱은 조각 사이에 공백을 넣지 않는다.
+- `correction_type` 은 저장 시 `original_text` 와 `corrected_text` 의 일치 여부로 결정된다 (§5.2 A5).
+
+### 2.7 `FEEDBACK_TIPS` — 학습 팁
+
+검토 화면 하단에 노출하는 한국어 학습 팁이다.
+
+| 컬럼 | 타입 | 제약 | 설명 |
+| --- | --- | --- | --- |
+| `feedback_tip_id` | BIGINT | PK, AUTO_INCREMENT | |
+| `feedback_id` | BIGINT | FK → `FEEDBACKS.feedback_id`, NOT NULL | |
+| `content` | VARCHAR(500) | NOT NULL | 한국어 설명 문장 |
+| `sort_order` | INT | NOT NULL | 표시 순서. 1부터 연속 증가 |
+
+- UNIQUE `(feedback_id, sort_order)` — `CORRECTION_SEGMENTS` 와 동일한 순서 보장 규칙을 적용한다.
+- 한 피드백당 0~3행이다. 디자인의 팁없음 / 팁단일 / 팁여러개 세 가지 상태에 대응한다.
+- 조회 시 `ORDER BY sort_order ASC` 로 정렬하고, API 응답에서는 `feedback.tips` 문자열 배열로 평탄화한다.
+
+---
+
+## 3. 연관관계
+
+### 3.1 매핑 정의
+
+| 관계 | 소유 측 (FK 보유) | 반대 측 | Fetch | Cascade | orphanRemoval |
+| --- | --- | --- | --- | --- | --- |
+| `Users` ↔ `TermsAgreements` | `TermsAgreements.user` `@ManyToOne` | `Users.termsAgreements` `@OneToMany(mappedBy="user")` | LAZY | ALL | true |
+| `Users` ↔ `Letters` | `Letters.user` `@ManyToOne` | `Users.letters` `@OneToMany(mappedBy="user")` | LAZY | ALL | true |
+| `Stamps` → `Letters` | `Letters.stamp` `@ManyToOne` | 단방향 (역방향 매핑 없음) | LAZY | 없음 | false |
+| `Letters` ↔ `Feedbacks` | `Feedbacks.letter` `@OneToOne` | `Letters.feedback` `@OneToOne(mappedBy="letter")` | LAZY | ALL | true |
+| `Feedbacks` ↔ `CorrectionSegments` | `CorrectionSegments.feedback` `@ManyToOne` | `Feedbacks.correctionSegments` `@OneToMany(mappedBy="feedback")` | LAZY | ALL | true |
+| `Feedbacks` ↔ `FeedbackTips` | `FeedbackTips.feedback` `@ManyToOne` | `Feedbacks.tips` `@OneToMany(mappedBy="feedback")` | LAZY | ALL | true |
+
+`Stamps` 는 마스터 데이터라 편지 쪽에서만 참조하는 단방향이다. cascade 를 걸지 않으므로 편지·유저 삭제가 우표 행에 영향을 주지 않는다.
+
+### 3.2 연관관계 편의 메서드
+
+양방향 관계의 동기화는 정적 팩토리 메서드 안에서 이뤄진다. 생성자는 `private` 이므로 한쪽만 세팅된 상태는 만들어지지 않는다.
+
+| 생성 메서드 | 내부 동기화 |
+| --- | --- |
+| `TermsAgreements.create(user, …)` | `user.addTermsAgreement(agreement)` |
+| `Letters.create(user, …)` | `user.addLetter(letter)` |
+| `Feedbacks.create(letter, …)` | `letter.registerFeedback(feedback)` |
+| `CorrectionSegments.create(feedback, …)` | `feedback.addCorrectionSegment(segment)` |
+| `FeedbackTips.create(feedback, …)` | `feedback.addTip(tip)` |
+
+### 3.3 삭제 전파
+
+`Users` → (`TermsAgreements`, `Letters`) → `Feedbacks` → (`CorrectionSegments`, `FeedbackTips`) 순으로 JPA cascade 가 전 구간 연쇄 삭제한다. 회원탈퇴 유예기간이 끝났을 때의 전량 삭제(R8) 요건은 이 경로 하나로 충족한다.
+
+- **삭제 순서를 코드가 직접 지정하지 않는다.** 유예기간 만료 배치는 `Users` 엔티티를 조회해 `delete(user)` 만 호출하고, 나머지는 cascade 에 맡긴다.
+- cascade 는 영속성 컨텍스트를 거칠 때만 동작하므로, 삭제는 항상 엔티티를 조회한 뒤 `delete(entity)` 로 수행한다. 벌크 DELETE 쿼리는 사용하지 않는다.
+- DB 레벨 `ON DELETE CASCADE` 는 걸지 않는다. 삭제 경로를 애플리케이션 한 곳으로 통일하기 위해서다.
+
+### 3.4 조회 전략
+
+- `@OneToOne(mappedBy)` 인 `Letters.feedback` 은 FK 미보유 측이라 Hibernate 가 프록시를 만들 수 없고 항상 즉시 로딩된다. 따라서 **편지 목록 조회는 엔티티 그래프를 타지 않고 DTO projection 으로 처리**한다.
+- 편지·피드백 상세 조회는 `LETTERS` → `FEEDBACKS` → `CORRECTION_SEGMENTS` / `FEEDBACK_TIPS` 를 `fetch join` 으로 한 번에 가져온다. 컬렉션이 둘이므로 `CORRECTION_SEGMENTS` 만 join 하고 `FEEDBACK_TIPS` 는 `@BatchSize` 로 로딩해 MultipleBagFetchException 을 피한다.
+- 홈의 우표 카운트는 엔티티 로딩 없이 `count` 쿼리로 계산한다.
+- 목록 응답의 `stampImage` 는 `LETTERS` 와 `STAMPS` 를 join 해 DTO 로 한 번에 가져온다. 행 수가 적고 변경이 드문 마스터 데이터이므로 2차 캐시 적용 대상이다.
+- 약관 동의 상태는 `(user_id, type)` 별 최신 1행을 뽑는 조회다. 항목이 3개뿐이므로 `user_id` 로 전체를 가져와 애플리케이션에서 `type` 별 최신을 고르거나, 윈도우 함수로 한 번에 조회한다.
+
+---
+
+## 4. Enum 정의
+
+모두 `EnumType.STRING` 으로 저장한다. `ORDINAL` 은 사용하지 않는다.
+
+우표 종류는 enum 이 아니라 `STAMPS` 테이블의 행으로 관리한다 (§2.4).
+
+### 4.1 `OauthProvider` — `USERS.oauth_provider`
+
+| 값 | 설명 |
+| --- | --- |
+| `KAKAO` | 카카오 로그인 |
+| `APPLE` | 애플 로그인 |
+
+API 요청/응답의 `provider` 필드가 이 enum 이다. 문서 전체에서 이름을 `OauthProvider` 로 통일한다.
+
+### 4.2 `Role` — `USERS.role`
+
+| 값 | 설명 |
+| --- | --- |
+| `ROLE_USER` | 일반 사용자. `Users.create(…)` 의 기본값 |
+| `ROLE_ADMIN` | 관리자. `Users.createAdmin(…)` 로만 생성 |
+
+MVP 에는 관리자 전용 API 가 없다. `ROLE_ADMIN` 은 운영자 수동 재처리(§6.1) 같은 후속 경로를 위해 스키마에만 존재한다.
+
+### 4.3 `UserStatus` — `USERS.status`
+
+| 값 | 설명 |
+| --- | --- |
+| `ACTIVE` | 정상 이용 중 |
+| `WITHDRAWN` | 탈퇴 처리됨. 모든 API 접근 차단(`AUTH_007`). 유예기간 경과 후 행 삭제 (§6.2) |
+
+### 4.4 `TermsType` — `TERMS_AGREEMENTS.type`
+
+| 값 | 필수 여부 | 설명 |
+| --- | --- | --- |
+| `SERVICE` | 필수 | 서비스 이용약관 |
+| `PRIVACY` | 필수 | 개인정보 처리방침 |
+| `MARKETING` | 선택 | 마케팅 수신 동의. 설정에서 철회할 수 있다 |
+
+`SERVICE` 와 `PRIVACY` 의 최신 행이 모두 `agreed = true` 여야 온보딩 약관 단계를 통과한 것으로 본다.
+
+### 4.5 `Status` — `LETTERS.status`
+
+| 값 | 의미 | 앱 표현 |
+| --- | --- | --- |
+| `SUBMITTED` | 제출됨, 워커 픽업 대기 | 회색 `soon` 우표, 상세 진입 불가 (R5) |
+| `FEEDBACK_IN_PROGRESS` | 워커가 픽업해 LLM 호출 중 | 회색 `soon` 우표, 상세 진입 불가 (`SUBMITTED` 와 동일) |
+| `FEEDBACK_COMPLETED` | 피드백 완료 | 컬러 우표, 상세 진입 가능 |
+| `FEEDBACK_FAILED` | 피드백 실패 (내부 전용) | API 응답에서는 `SUBMITTED` 로 변환해 내려보낸다 |
+
+전이 규칙은 [기능명세 §2.2](./기능명세.md#22-편지-상태-전이) 를 따른다. 임시저장 상태는 두지 않으며, 편지는 항상 `SUBMITTED` 로 생성된다.
+
+- 컬럼 길이가 VARCHAR(30) 인 이유는 가장 긴 값 `FEEDBACK_IN_PROGRESS` 가 20자이기 때문이다. 여유를 포함해 30으로 잡는다.
+- `FEEDBACK_IN_PROGRESS` 는 워커 중복 실행 방지와 처리 유실 판별을 위한 상태다. 두 워커가 같은 편지를 집지 못하도록 진입을 조건부 UPDATE 로 막고, 이 상태로 15분 이상 머문 편지는 호출 도중 종료된 것으로 보고 `SUBMITTED` 로 되돌려 재큐잉한다.
+- `FEEDBACK_IN_PROGRESS` 는 API 응답에 그대로 내려간다. 앱은 `FEEDBACK_COMPLETED` 인지 아닌지만 구분하므로 `SUBMITTED` 와 동일하게 렌더링한다. 내부 전용인 `FEEDBACK_FAILED` 만 `SUBMITTED` 로 치환한다.
+
+### 4.6 `CorrectionType` — `CORRECTION_SEGMENTS.correction_type`
+
+| 값 | 설명 | 앱 렌더링 |
+| --- | --- | --- |
+| `UNCHANGED` | 교정 없음 | 검은 글씨 그대로 |
+| `MODIFIED` | 교정됨 | 원문에 빨간 취소선 + 뒤에 교정문 초록 하이라이트 |
+
+문법·어휘·철자 등 세부 교정 카테고리는 두지 않는다. API 응답에서의 필드명은 `type` 이다 (§2.6).
+
+---
+
+## 5. 제약 조건
+
+### 5.1 DB 제약
+
+| 종류 | 대상 |
+| --- | --- |
+| PRIMARY KEY | `USERS.user_id`, `TERMS_AGREEMENTS.terms_agreement_id`, `LETTERS.letter_id`, `STAMPS.stamp_id`, `FEEDBACKS.feedback_id`, `CORRECTION_SEGMENTS.correction_segment_id`, `FEEDBACK_TIPS.feedback_tip_id` |
+| FOREIGN KEY | `TERMS_AGREEMENTS.user_id` → `USERS`, `LETTERS.user_id` → `USERS`, `LETTERS.stamp_id` → `STAMPS`, `FEEDBACKS.letter_id` → `LETTERS`, `CORRECTION_SEGMENTS.feedback_id` → `FEEDBACKS`, `FEEDBACK_TIPS.feedback_id` → `FEEDBACKS` |
+| UNIQUE | `USERS (oauth_provider, oauth_id)`, `STAMPS.name`, `FEEDBACKS.letter_id`, `CORRECTION_SEGMENTS (feedback_id, sequence)`, `FEEDBACK_TIPS (feedback_id, sort_order)` |
+| INDEX | `LETTERS (user_id, letter_date DESC, letter_id DESC)`, `LETTERS (status, updated_at)`, `TERMS_AGREEMENTS (user_id, type, agreed_at DESC)` |
+| DEFAULT | `LETTERS.is_read = false`, `LETTERS.retry_count = 0`, `STAMPS.is_active = true` |
+| NULL 허용 | `USERS.email`, `USERS.nickname`, `USERS.refresh_token`, `USERS.deleted_at`, `LETTERS.stamp_id` — 나머지 전 컬럼 NOT NULL |
+
+`TERMS_AGREEMENTS` 에는 UNIQUE 를 두지 않는다. 이력 테이블이므로 같은 `(user_id, type)` 조합이 여러 번 나타나는 것이 정상이다.
+
+### 5.2 애플리케이션이 보장하는 불변식
+
+| # | 규칙 | 근거 | 강제 위치 |
+| --- | --- | --- | --- |
+| A1 | `content` 는 한글을 포함하지 않고 1~500자 | R2 | Bean Validation + 서비스 |
+| A2 | 편지는 등록 후 `content` · `letter_date` 불변, 사용자 삭제 불가 | R1 | 편지 엔티티에 해당 수정 메서드를 두지 않음 |
+| A3 | `letter_date` 는 요청의 `writtenAt` 을 `timeZone` 기준으로 환산한 날짜다. 환산 시각이 서버 현재 시각 ±24시간을 벗어나면 거부한다 | R9 | 편지 작성 서비스 |
+| A4 | `nickname` 은 영문·숫자 1~20자 (NULL 이 아닌 경우) | R7 | `UserValidationConstants` |
+| A5 | `correction_type` 은 `original_text.equals(corrected_text)` 이면 `UNCHANGED`, 아니면 `MODIFIED` | — | `CorrectionSegments` 생성자 |
+| A6 | `concat(original_text ORDER BY sequence)` == `LETTERS.content` | 기능명세 §3.5.3 | 피드백 저장 트랜잭션 |
+| A7 | `concat(corrected_text ORDER BY sequence)` == `FEEDBACKS.corrected_content` | 기능명세 §3.5.3 | 피드백 저장 트랜잭션 |
+| A8 | `FEEDBACK_TIPS` 는 피드백당 최대 3행 | 기능명세 §3.5.2 | 피드백 저장 트랜잭션 |
+| A9 | `status = 'FEEDBACK_COMPLETED'` 이면 `stamp_id` 는 NOT NULL, 그 외 상태면 NULL | R3 | 상태 전이 메서드 |
+| A9-1 | `stamp_id` 는 `is_active = true` 인 우표 중에서만 부여한다. 부여 후 우표가 비활성화돼도 기존 값은 유지한다 | — | 우표 부여 로직 |
+| A9-2 | LLM 이 반환한 우표 이름이 후보 목록에 없으면 활성 우표 중 랜덤 1개로 대체한다 | — | 우표 부여 로직 |
+| A10 | `FEEDBACKS` 행이 존재하면 `LETTERS.status` 는 `FEEDBACK_COMPLETED` | — | 피드백 저장 트랜잭션 |
+| A11 | `SUBMITTED → FEEDBACK_IN_PROGRESS` 전이는 조건부 UPDATE 로만 수행하고, 갱신 건수 0이면 처리를 중단한다 | 기능명세 §3.5.1 | 피드백 워커 |
+| A12 | `retry_count > 3` 이면 `status = 'FEEDBACK_FAILED'` | 기능명세 §2.2 | 피드백 워커 |
+| A13 | `status = 'WITHDRAWN'` 이면 `deleted_at` NOT NULL, `refresh_token` NULL | R8 | 탈퇴 서비스 |
+| A14 | `refresh_token` 은 유저당 1개만 유지 (단일 세션) | — | 인증 서비스 |
+| A15 | 온보딩 완료 = `SERVICE` · `PRIVACY` 의 최신 행이 모두 `agreed = true` **그리고** `nickname IS NOT NULL` | 기능명세 §3.2 | 온보딩 가드 (`USER_005`) |
+| A16 | `TERMS_AGREEMENTS` 는 UPDATE 하지 않고 INSERT 만 한다 | §2.2 | 약관 동의 서비스 |
+| A17 | 동일 유저가 60초 이내에 같은 `content` 를 다시 보내면 새 행을 만들지 않고 최초 편지를 반환한다 | 기능명세 §3.4.4 | 편지 작성 서비스 |
+
+---
+
+## 6. 데이터 수명주기
+
+### 6.1 편지
+
+편지는 append-only 다. 작성되면 `SUBMITTED` 로 저장되고, 워커가 픽업하면 `FEEDBACK_IN_PROGRESS`, 저장에 성공하면 `FEEDBACK_COMPLETED` 로 전이한다. LLM 호출이 실패하면 `SUBMITTED` 로 되돌려 재시도하고, 3회를 넘기면 `FEEDBACK_FAILED` 로 확정한다. 사용자에게 노출되는 삭제 경로는 회원탈퇴뿐이다.
+
+| 전이 | 트리거 | 함께 갱신되는 컬럼 |
+| --- | --- | --- |
+| → `SUBMITTED` | 편지 작성 | `is_read = false`, `retry_count = 0` |
+| `SUBMITTED` → `FEEDBACK_IN_PROGRESS` | 워커 픽업 (조건부 UPDATE) | `updated_at` |
+| `FEEDBACK_IN_PROGRESS` → `FEEDBACK_COMPLETED` | LLM 응답 저장 성공 | `stamp_id` 부여, `updated_at` |
+| `FEEDBACK_IN_PROGRESS` → `SUBMITTED` | LLM 실패 재시도 (워커가 백오프 후 재예약) | `retry_count++`, `updated_at` |
+| `FEEDBACK_IN_PROGRESS` → `SUBMITTED` | 처리 유실 감지 (15분 초과) | `updated_at` |
+| `SUBMITTED` → `SUBMITTED` | 이벤트·재예약 유실 감지 (1시간 초과) 후 재큐잉 | `updated_at` |
+| `FEEDBACK_IN_PROGRESS` → `FEEDBACK_FAILED` | 재시도 3회 초과 · 복구 불가 오류 | `updated_at` |
+| `FEEDBACK_FAILED` → `SUBMITTED` | 운영자 수동 재처리 | `retry_count = 0`, `updated_at` |
+
+### 6.2 회원탈퇴 — soft delete 후 지연 삭제
+
+| 단계 | 시점 | 처리 |
+| --- | --- | --- |
+| 1. 탈퇴 요청 | 즉시 | `status = 'WITHDRAWN'`, `deleted_at = now()`, `refresh_token = NULL`. 이후 모든 API 접근이 `AUTH_007` 로 차단된다 |
+| 2. 유예기간 | 30일 | 데이터는 보존한다. 사용자에게 노출되는 복구 수단은 없다 |
+| 3. 완전 삭제 | `deleted_at + 30일` 경과 | 배치가 `USERS` 행을 삭제하고, cascade 로 약관 이력·편지·피드백·교정 조각·팁까지 전량 제거한다 (§3.3) |
+
+- **탈퇴한 계정으로 다시 로그인하면 항상 신규 가입으로 처리한다.** 이전 편지는 복원되지 않는다.
+- 유예기간 중인 계정은 `(oauth_provider, oauth_id)` UNIQUE 를 점유하므로, 재로그인 시점에 기존 행의 `oauth_id` 를 `{oauth_id}#withdrawn#{deleted_at 에폭밀리}` 형태로 치환해 UNIQUE 를 비우고 새 행을 만든다. 치환 후에도 삭제 배치는 `deleted_at` 으로 대상을 식별하므로 영향이 없다.
+- 2단계는 오삭제 복구·분쟁 대응을 위한 **내부 보존**이다. 앱 문구에는 노출하지 않으며, 개인정보처리방침의 보유기간 항목에 명시한다 (기능명세 §4.1).
+- 3단계 삭제는 되돌릴 수 없다 (R8).
+
+### 6.3 약관 동의 이력
+
+`TERMS_AGREEMENTS` 는 UPDATE 하지 않고 INSERT 만 하는 이력 테이블이다 (§2.2, A16).
+
+- 온보딩에서 약관에 동의하면 `SERVICE` · `PRIVACY` · `MARKETING` 3행이 한 번에 쌓인다.
+- 설정에서 마케팅 동의를 철회하면 `type = 'MARKETING'`, `agreed = false` 행이 하나 더 쌓인다. 이전 행은 그대로 남는다.
+- 현재 동의 상태를 알고 싶으면 `(user_id, type)` 별 `agreed_at` 최신 행을 본다.
+- 유저 행이 삭제되면 동의 이력도 cascade 로 함께 삭제된다 (§3.3). 탈퇴 이력은 개인정보를 제외한 최소 정보만 애플리케이션 로그로 별도 보관한다.
+
+---
+
+## 7. 부록: DDL
+
+Flyway 마이그레이션 `V1__init.sql` 의 내용이다. 이 문서와 마이그레이션 스크립트가 어긋나면 **이 문서를 기준으로 스크립트를 고친다.**
+
+```sql
+CREATE TABLE users (
+    user_id        BIGINT       NOT NULL AUTO_INCREMENT,
+    oauth_provider VARCHAR(10)  NOT NULL,
+    oauth_id       VARCHAR(255) NOT NULL,
+    email          VARCHAR(255) NULL,
+    nickname       VARCHAR(20)  NULL,
+    role           VARCHAR(20)  NOT NULL,
+    status         VARCHAR(20)  NOT NULL,
+    refresh_token  VARCHAR(500) NULL,
+    created_at     DATETIME(6)  NOT NULL,
+    updated_at     DATETIME(6)  NOT NULL,
+    deleted_at     DATETIME(6)  NULL,
+    PRIMARY KEY (user_id),
+    UNIQUE KEY uk_users_oauth (oauth_provider, oauth_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE terms_agreements (
+    terms_agreement_id BIGINT      NOT NULL AUTO_INCREMENT,
+    user_id            BIGINT      NOT NULL,
+    type               VARCHAR(20) NOT NULL,
+    agreed             BOOLEAN     NOT NULL,
+    terms_version      VARCHAR(20) NOT NULL,
+    agreed_at          DATETIME(6) NOT NULL,
+    PRIMARY KEY (terms_agreement_id),
+    CONSTRAINT fk_terms_user FOREIGN KEY (user_id) REFERENCES users (user_id),
+    KEY idx_terms_latest (user_id, type, agreed_at DESC)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE stamps (
+    stamp_id    BIGINT       NOT NULL AUTO_INCREMENT,
+    name        VARCHAR(30)  NOT NULL,
+    description VARCHAR(100) NOT NULL,
+    image_url   VARCHAR(500) NOT NULL,
+    is_active   BOOLEAN      NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (stamp_id),
+    UNIQUE KEY uk_stamps_name (name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE letters (
+    letter_id   BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id     BIGINT       NOT NULL,
+    stamp_id    BIGINT       NULL,
+    content     VARCHAR(500) NOT NULL,
+    letter_date DATE         NOT NULL,
+    status      VARCHAR(30)  NOT NULL,
+    is_read     BOOLEAN      NOT NULL DEFAULT FALSE,
+    retry_count INT          NOT NULL DEFAULT 0,
+    created_at  DATETIME(6)  NOT NULL,
+    updated_at  DATETIME(6)  NOT NULL,
+    PRIMARY KEY (letter_id),
+    CONSTRAINT fk_letters_user FOREIGN KEY (user_id) REFERENCES users (user_id),
+    CONSTRAINT fk_letters_stamp FOREIGN KEY (stamp_id) REFERENCES stamps (stamp_id),
+    KEY idx_letters_list (user_id, letter_date DESC, letter_id DESC),
+    KEY idx_letters_pending (status, updated_at)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE feedbacks (
+    feedback_id       BIGINT        NOT NULL AUTO_INCREMENT,
+    letter_id         BIGINT        NOT NULL,
+    corrected_content VARCHAR(1000) NOT NULL,
+    model             VARCHAR(50)   NOT NULL,
+    created_at        DATETIME(6)   NOT NULL,
+    PRIMARY KEY (feedback_id),
+    UNIQUE KEY uk_feedbacks_letter (letter_id),
+    CONSTRAINT fk_feedbacks_letter FOREIGN KEY (letter_id) REFERENCES letters (letter_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE correction_segments (
+    correction_segment_id BIGINT       NOT NULL AUTO_INCREMENT,
+    feedback_id           BIGINT       NOT NULL,
+    sequence              INT          NOT NULL,
+    original_text         VARCHAR(500) NOT NULL,
+    corrected_text        VARCHAR(500) NOT NULL,
+    correction_type       VARCHAR(20)  NOT NULL,
+    PRIMARY KEY (correction_segment_id),
+    UNIQUE KEY uk_segments_order (feedback_id, sequence),
+    CONSTRAINT fk_segments_feedback FOREIGN KEY (feedback_id) REFERENCES feedbacks (feedback_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE feedback_tips (
+    feedback_tip_id BIGINT       NOT NULL AUTO_INCREMENT,
+    feedback_id     BIGINT       NOT NULL,
+    content         VARCHAR(500) NOT NULL,
+    sort_order      INT          NOT NULL,
+    PRIMARY KEY (feedback_tip_id),
+    UNIQUE KEY uk_tips_order (feedback_id, sort_order),
+    CONSTRAINT fk_tips_feedback FOREIGN KEY (feedback_id) REFERENCES feedbacks (feedback_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+```
+
+### 초기 데이터
+
+```sql
+INSERT INTO stamps (name, description, image_url, is_active) VALUES
+    ('장미',      '마음을 담아 건네는 붉은 장미',        '{CDN_BASE_URL}/stamps/flower_stamp.png',  TRUE),
+    ('호박',      '포근하고 든든한 가을 호박',           '{CDN_BASE_URL}/stamps/pumpkin_stamp.png', TRUE),
+    ('네잎클로버', '오늘 하루에 깃든 작은 행운',          '{CDN_BASE_URL}/stamps/clover_stamp.png',  TRUE),
+    ('초승달',    '조용히 하루를 마무리하는 밤의 달',     '{CDN_BASE_URL}/stamps/moon_stamp.png',    TRUE);
+```
+
+우표를 추가할 때는 이 테이블에 행을 넣는 것으로 끝난다. 프롬프트 후보 목록과 앱 응답에 자동으로 반영된다.

--- a/docs/기능명세.md
+++ b/docs/기능명세.md
@@ -5,11 +5,16 @@
 
 | 항목 | 내용 |
 | --- | --- |
-| 문서 버전 | v1.0 (MVP) |
+| 최종 갱신 | 2026-08-22 |
 | 대상 | 서버 개발자 |
 | 앱 버전 | 1.0.0 (MVP) |
-| 기술 스택 | Java 21, Spring Boot 3.5.7, Spring Data JPA, MySQL, Bean Validation |
-| 기준 시간대 | `Asia/Seoul` (KST). 모든 "날짜" 개념은 KST 기준 |
+| 기술 스택 | Java 21, Spring Boot 3.5.7, Spring Data JPA, MySQL, Flyway, Bean Validation |
+| 서버 기준 시간대 | `Asia/Seoul` (KST). **편지 날짜만 클라이언트가 보낸 타임존을 따른다** (R9) |
+
+> **문서 역할 분담**
+> - **이 문서**: 도메인 규칙 · 처리 흐름 · 비기능 요구사항
+> - [ERD.md](./ERD.md): **데이터 모델의 정본**. 테이블 · 컬럼 · Enum · 제약 조건
+> - [API명세.md](./API명세.md): **요청/응답 계약의 정본**. 엔드포인트 · 필드 · 에러 코드 · 메시지
 
 ---
 
@@ -17,21 +22,18 @@
 
 1. [범위와 전제](#1-범위와-전제)
 2. [시스템 구성](#2-시스템-구성)
-3. [도메인 모델 / ERD](#3-도메인-모델--erd)
-4. [공통 규약](#4-공통-규약)
-5. [기능 명세](#5-기능-명세)
-   - 5.1 [인증 / 계정](#51-인증--계정)
-   - 5.2 [온보딩 (약관 · 닉네임)](#52-온보딩-약관--닉네임)
-   - 5.3 [홈 (편지 목록 · 우표 카운트)](#53-홈-편지-목록--우표-카운트)
-   - 5.4 [편지 작성](#54-편지-작성)
-   - 5.5 [AI 검토 파이프라인](#55-ai-검토-파이프라인)
-   - 5.6 [편지 검토 조회](#56-편지-검토-조회)
-   - 5.7 [설정 / 부가](#57-설정--부가)
-6. [에러 코드](#6-에러-코드)
-7. [비기능 요구사항](#7-비기능-요구사항)
-8. [추가로 필요한 의존성 · 환경변수](#8-추가로-필요한-의존성--환경변수)
-9. [확정 필요 항목 (Open Questions)](#9-확정-필요-항목-open-questions)
-10. [MVP 이후 확장 고려](#10-mvp-이후-확장-고려)
+3. [기능 명세](#3-기능-명세)
+   - 3.1 [인증 / 계정](#31-인증--계정)
+   - 3.2 [온보딩 (약관 · 닉네임)](#32-온보딩-약관--닉네임)
+   - 3.3 [홈 (편지 목록 · 우표 카운트)](#33-홈-편지-목록--우표-카운트)
+   - 3.4 [편지 작성](#34-편지-작성)
+   - 3.5 [AI 피드백 파이프라인](#35-ai-피드백-파이프라인)
+   - 3.6 [편지 · 피드백 상세 조회](#36-편지--피드백-상세-조회)
+   - 3.7 [설정 / 부가](#37-설정--부가)
+4. [비기능 요구사항](#4-비기능-요구사항)
+5. [추가로 필요한 의존성 · 환경변수](#5-추가로-필요한-의존성--환경변수)
+6. [주요 설계 결정](#6-주요-설계-결정)
+7. [MVP 이후 확장 고려](#7-mvp-이후-확장-고려)
 
 ---
 
@@ -39,32 +41,38 @@
 
 ### 1.1 MVP 범위 (IN)
 
-- 카카오 / 애플 소셜 로그인, 토큰 재발급, 로그아웃, 회원탈퇴
-- 약관 동의, 닉네임 등록 및 변경
+- 카카오 / 애플 소셜 로그인 (회원가입 포함), 토큰 재발급, 로그아웃, 회원탈퇴
+- 약관 동의 및 마케팅 동의 철회, 닉네임 등록 및 변경
 - 영어 편지 작성 (최대 500자, 영어 전용)
-- AI 기반 편지 검토(교정 + 팁) 비동기 처리
-- 편지 목록 조회 (최신순 / 오래된순), 우표 카운트, 미열람 표시
-- 편지 상세(검토 결과) 조회
-- 공지사항 · 개인정보처리방침 · 앱 버전 노출
+- AI 기반 편지 피드백(교정 + 팁) 비동기 처리
+- 편지 목록 조회(최신순 / 오래된순), 우표 카운트, 미열람 표시
+- 편지 · 피드백 상세 조회
+- 최소 지원 버전 · 정책 URL 제공
 
 ### 1.2 MVP 범위 밖 (OUT)
 
 - 푸시 알림, 위젯, 일기 프롬프트, 표현/단어 정리, 결제/유료 첨삭
-- 편지 수정 · 삭제 (전달된 편지는 다시 고칠 수 없음 — 기획 확정 사항)
-- 편지 재검토 요청
+- 임시저장 — 작성 화면에서 곧바로 `전달하기` 로 제출한다
+- 편지 수정 · 삭제 (전달된 편지는 다시 고칠 수 없음)
+- 피드백 재요청, 공지사항 API (웹뷰 링크로 대체)
+- 약관 개정 시 **재동의 유도** — 동의 시점의 약관 버전은 기록하되, 기존 유저에게 다시 묻지 않는다 (§3.2.1)
+- 관리자 API — `ROLE_ADMIN` 은 스키마에만 존재하고 노출 엔드포인트가 없다
 
-### 1.3 핵심 도메인 규칙 요약
+### 1.3 핵심 도메인 규칙
 
 | # | 규칙 |
 | --- | --- |
 | R1 | 편지는 **전달(작성 완료) 후 수정·삭제 불가**. 등록은 append-only |
 | R2 | 편지 본문은 **영어만 허용**, **1~500자** |
-| R3 | 우표는 **검토(AI 피드백)가 완료된 편지에만** 부여된다. 작성 수 ≠ 우표 수 |
-| R4 | 홈의 "총 N개의 우표" = `status = COMPLETED` 인 편지 수 |
-| R5 | 검토 완료 전(`PENDING`/`PROCESSING`) 편지는 **상세 진입 불가** (회색 `soon` 우표) |
-| R6 | 검토 완료 후 아직 열람하지 않은 편지는 **미열람 표시(빨간 점)** |
-| R7 | 닉네임은 **영문/숫자만, 1~20자** (공백·특수기호·한글 불가) |
-| R8 | 회원탈퇴 시 편지·계정 정보 전부 삭제 (복구 불가) |
+| R3 | 우표는 **피드백이 완료된 편지에만** 부여된다. 작성 수 ≠ 우표 수 |
+| R4 | 홈의 우표 수 = 피드백 완료 상태인 편지 수 |
+| R5 | 피드백 완료 전 편지는 **상세 진입 불가** (회색 `soon` 우표) |
+| R6 | 피드백 완료 후 아직 열람하지 않은 편지는 **미열람 표시** |
+| R7 | 닉네임은 **영문/숫자만, 1~20자**. 중복은 허용한다 |
+| R8 | 회원탈퇴 시 편지·계정 정보 전부 삭제 (사용자 관점에서 복구 불가). 서버는 **30일 유예 후 완전 삭제**한다 |
+| R9 | 편지 날짜는 **클라이언트가 보낸 작성 시각 + 타임존**으로 결정한다 |
+| R10 | 하루 작성 개수에 **제한이 없다**. 같은 날짜 카드가 여러 개 쌓일 수 있다 |
+| R11 | 온보딩(필수 약관 동의 + 닉네임 등록)을 마치기 전에는 **본 기능 API 를 사용할 수 없다** |
 
 ---
 
@@ -76,12 +84,14 @@ flowchart LR
     API --> DB[(MySQL)]
     API -->|OAuth 검증| KAKAO["Kakao API"]
     API -->|OAuth 검증| APPLE["Apple ID Server"]
-    API -.->|비동기 검토 요청| WORKER["Feedback Worker<br/>(@Async / 이벤트)"]
+    API -.->|비동기 피드백 요청| WORKER["Feedback Worker<br/>(@Async / 이벤트)"]
     WORKER --> LLM["LLM (Claude API)"]
     WORKER --> DB
+    SCHED["보완 스케줄러<br/>(10분 주기)"] --> DB
+    SCHED -.->|재큐잉| WORKER
 ```
 
-### 2.1 패키지 구조 (현행 유지)
+### 2.1 패키지 구조
 
 ```
 com.dearjolly.server
@@ -89,283 +99,59 @@ com.dearjolly.server
 ├── domain
 │   ├── user      / controller, service, repository, entity, dto, enums, constants
 │   ├── letter    / controller, service, repository, entity, dto, enums
-│   └── feedback  / controller, service, repository, entity, dto, enums
+│   └── feedback  / service, repository, entity, dto, enums
 └── global
     ├── exception / controller, exception, handler, response
-    ├── auth      (신규: JWT 필터, 인증 principal, OAuth 클라이언트)
-    ├── config    (신규: Security, Async, RestClient, Jackson)
+    ├── auth      (신규: JWT 필터, 인증 principal, OAuth 클라이언트, 온보딩 가드)
+    ├── version   (신규: 최소 지원 버전 · 정책 URL 조회)
+    ├── config    (신규: Security, Async, Scheduling, RestClient, Jackson)
     └── common    (신규: BaseTimeEntity 등)
 ```
 
+- **`version` 은 도메인이 아니라 `global` 하위**에 둔다. 유저·편지 어느 애그리거트에도 속하지 않는 앱 메타 정보이기 때문이다.
+- **`GET /api/v1/home` 은 `letter` 도메인**에 둔다. 닉네임은 유저에서 오지만 응답의 본질은 편지 집계(우표 수)이고, `GET /api/v1/letters` 와 같은 서비스 메서드를 공유해야 하기 때문이다 (§3.3.2).
+- `feedback` 도메인에는 controller 가 없다. 피드백은 편지 상세 응답에 포함돼 나가며 독립 엔드포인트를 갖지 않는다.
+- `terms` 는 별도 도메인이 아니라 `user` 하위의 엔티티·서비스로 둔다. 약관 동의는 유저 애그리거트의 일부다.
+
 > 기존 `domain/skeleton/**` 은 참고용 템플릿이므로 실제 도메인 구현 완료 후 제거한다.
 
-### 2.2 상태 전이
+### 2.2 편지 상태 전이
 
 ```mermaid
 stateDiagram-v2
-    [*] --> PENDING: 편지 전달하기
-    PENDING --> PROCESSING: 워커 픽업
-    PROCESSING --> COMPLETED: LLM 응답 파싱/저장 성공 (우표 부여)
-    PROCESSING --> PENDING: 재시도 (최대 3회)
-    PROCESSING --> FAILED: 재시도 초과 / 복구 불가 오류
-    FAILED --> PENDING: 운영자 수동 재처리
+    [*] --> SUBMITTED: 편지 전달하기
+    SUBMITTED --> FEEDBACK_IN_PROGRESS: 워커 픽업 (LLM 호출 직전)
+    FEEDBACK_IN_PROGRESS --> FEEDBACK_COMPLETED: LLM 응답 파싱/저장 성공 (우표 부여)
+    FEEDBACK_IN_PROGRESS --> SUBMITTED: 재시도 (최대 3회, 백오프 후 워커가 재예약)
+    FEEDBACK_IN_PROGRESS --> FEEDBACK_FAILED: 재시도 초과 / 복구 불가 오류
+    FEEDBACK_IN_PROGRESS --> SUBMITTED: 처리 유실 감지 (15분 초과)
+    SUBMITTED --> SUBMITTED: 이벤트·재예약 유실 감지 (1시간 초과) 후 재큐잉
+    FEEDBACK_FAILED --> SUBMITTED: 운영자 수동 재처리
 ```
+
+- `FEEDBACK_IN_PROGRESS` 는 워커가 편지를 집어 LLM 을 호출하고 있는 구간이다. 이 상태에 진입할 때 `updated_at` 이 갱신되므로, **워커 중복 실행 방지와 처리 유실 판별**에 사용한다 (§3.5.1).
+- `FEEDBACK_FAILED` 는 **내부 상태**다. 사용자에게 실패를 노출하지 않는다.
+- 앱은 피드백 완료 여부만 구분하면 된다. 완료 전 상태는 모두 동일하게 회색 `soon` 우표로 렌더링한다.
+
+### 2.3 예외 처리 규약
+
+- 도메인 예외는 `BusinessException` 으로 던지고 `GlobalExceptionHandler` 가 `ErrorResponse` 로 변환한다.
+- 에러 코드는 `ErrorCode` enum 에 `(HttpStatus, code, message)` 로 정의한다. 코드 체계는 `AUTH_` / `USER_` / `LETTER_` / `COMMON_` 이다.
+- 검증 실패(`MethodArgumentNotValidException`)는 핸들러에서 해당 도메인 코드로 변환한다.
+- **코드 · 상태 · 메시지 정본은 [API명세 §7](./API명세.md#7-에러-코드)** 이다. 이 문서는 각 기능의 검증 규칙과 위반 시 코드만 다룬다.
+- 공통 핸들러가 직접 생산하는 코드(`COMMON_001`~`COMMON_005`, `AUTH_006`)는 개별 기능에 매핑되지 않는다. 상세는 API명세 §2.3 참고.
 
 ---
 
-## 3. 도메인 모델 / ERD
+## 3. 기능 명세
 
-```mermaid
-erDiagram
-    USERS ||--o{ LETTERS : writes
-    USERS ||--o{ TERMS_AGREEMENTS : agrees
-    LETTERS ||--o| FEEDBACKS : has
-    FEEDBACKS ||--o{ CORRECTION_SEGMENTS : contains
-    FEEDBACKS ||--o{ FEEDBACK_TIPS : contains
-```
+> 엔드포인트 · 요청/응답 필드는 [API명세.md](./API명세.md) 를 따른다. 이 장은 **비즈니스 규칙과 처리 로직**을 다룬다.
 
-### 3.1 `users`
+### 3.1 인증 / 계정
 
-| 컬럼 | 타입 | 제약 | 설명 |
-| --- | --- | --- | --- |
-| `id` | BIGINT | PK, AI | |
-| `oauth_provider` | VARCHAR(10) | NOT NULL | `KAKAO` / `APPLE` |
-| `oauth_id` | VARCHAR(255) | NOT NULL | provider 고유 회원 식별자 (Kakao: `id`, Apple: `sub`) |
-| `email` | VARCHAR(255) | NULL | 설정 화면 노출용. Apple private relay / 미제공 가능 → NULL 허용 |
-| `nickname` | VARCHAR(20) | NULL | 온보딩 완료 전 NULL |
-| `role` | VARCHAR(10) | NOT NULL | `USER` / `ADMIN` (기존 `Role` enum) |
-| `status` | VARCHAR(20) | NOT NULL | `ACTIVE` / `WITHDRAWN` |
-| `refresh_token` | VARCHAR(500) | NULL | 최신 refresh token (단일 세션 정책) |
-| `created_at` / `updated_at` | DATETIME | NOT NULL | |
-| `deleted_at` | DATETIME | NULL | 탈퇴 시각 |
+#### 3.1.1 소셜 로그인 · 회원가입
 
-- UNIQUE: `(oauth_provider, oauth_id)`
-- 닉네임 **중복 허용** (표시용 이름, 디자인상 중복 에러 화면 없음) — [OQ-1](#9-확정-필요-항목-open-questions)
-
-### 3.2 `terms_agreements`
-
-| 컬럼 | 타입 | 제약 | 설명 |
-| --- | --- | --- | --- |
-| `id` | BIGINT | PK, AI | |
-| `user_id` | BIGINT | FK → users | |
-| `terms_type` | VARCHAR(30) | NOT NULL | `SERVICE`(필수) / `PRIVACY`(필수) / `MARKETING`(선택) |
-| `agreed` | BOOLEAN | NOT NULL | |
-| `agreed_at` | DATETIME | NOT NULL | 동의/철회 시각 |
-
-- UNIQUE: `(user_id, terms_type)`
-- 개인정보보호법상 **동의 이력 보존**이 필요하므로 users 컬럼이 아닌 별도 테이블로 관리
-
-### 3.3 `letters`
-
-| 컬럼 | 타입 | 제약 | 설명 |
-| --- | --- | --- | --- |
-| `id` | BIGINT | PK, AI | |
-| `user_id` | BIGINT | FK → users, NOT NULL | |
-| `content` | VARCHAR(500) | NOT NULL | 원문 (사용자 입력 그대로) |
-| `status` | VARCHAR(20) | NOT NULL | `PENDING` / `PROCESSING` / `COMPLETED` / `FAILED` (기존 `Status` enum) |
-| `stamp` | VARCHAR(30) | NULL | 검토 완료 시 부여 (기존 `Stamps` enum) |
-| `letter_date` | DATE | NOT NULL | KST 기준 작성 날짜. 목록 정렬/표시 기준 |
-| `is_read` | BOOLEAN | NOT NULL DEFAULT false | 검토 완료 후 사용자가 상세를 열었는지 |
-| `retry_count` | INT | NOT NULL DEFAULT 0 | 검토 재시도 횟수 |
-| `created_at` / `updated_at` | DATETIME | NOT NULL | |
-
-- INDEX: `(user_id, letter_date DESC, id DESC)` — 목록 커서 페이징용
-- INDEX: `(status)` — 미처리 편지 스캔용
-
-### 3.4 `feedbacks`
-
-| 컬럼 | 타입 | 제약 | 설명 |
-| --- | --- | --- | --- |
-| `id` | BIGINT | PK, AI | |
-| `letter_id` | BIGINT | FK → letters, UNIQUE | 편지 1 : 피드백 0..1 |
-| `corrected_content` | VARCHAR(1000) | NOT NULL | 교정이 모두 반영된 전체 문장 |
-| `model` | VARCHAR(50) | NOT NULL | 사용한 LLM 모델 ID (재현/과금 추적) |
-| `created_at` | DATETIME | NOT NULL | |
-
-### 3.5 `correction_segments`
-
-편지 원문 위에 **취소선(원문) + 초록 하이라이트(수정안)** 를 그리기 위한 데이터.
-
-| 컬럼 | 타입 | 제약 | 설명 |
-| --- | --- | --- | --- |
-| `id` | BIGINT | PK, AI | |
-| `feedback_id` | BIGINT | FK → feedbacks, NOT NULL | |
-| `correction_type` | VARCHAR(20) | NOT NULL | 기존 `CorrectionType` enum (§3.7) |
-| `original_text` | VARCHAR(200) | NOT NULL | 취소선으로 표시할 원문 조각 (`make`) |
-| `suggested_text` | VARCHAR(200) | NOT NULL | 초록으로 표시할 수정안 (`made`). 삭제 제안이면 빈 문자열 |
-| `start_index` | INT | NOT NULL | `letters.content` 기준 시작 오프셋 (0-based, inclusive) |
-| `end_index` | INT | NOT NULL | 종료 오프셋 (exclusive) |
-| `sort_order` | INT | NOT NULL | 화면 표시 순서 (= start_index 오름차순) |
-
-- 오프셋은 **UTF-16 code unit 이 아닌 코드포인트 기준**으로 통일하고, 앱과 계약을 맞춘다.
-- 세그먼트 구간은 서로 **겹치지 않아야 한다**. 겹치면 검증 실패로 간주하고 재시도 (§5.5.4)
-
-### 3.6 `feedback_tips`
-
-검토 화면 하단의 학습 팁. **0개 ~ n개** (디자인: 팁없음 / 팁단일 / 팁여러개).
-
-| 컬럼 | 타입 | 제약 | 설명 |
-| --- | --- | --- | --- |
-| `id` | BIGINT | PK, AI | |
-| `feedback_id` | BIGINT | FK → feedbacks, NOT NULL | |
-| `content` | VARCHAR(500) | NOT NULL | 한국어 설명 문장 |
-| `sort_order` | INT | NOT NULL | 표시 순서 |
-
-### 3.7 Enum 정의
-
-**`Status` (letter)**
-
-| 값 | 의미 | 앱 표현 |
-| --- | --- | --- |
-| `PENDING` | 전달 완료, 검토 대기 | 회색 `soon` 우표, 진입 불가 |
-| `PROCESSING` | 검토 진행 중 | 위와 동일 |
-| `COMPLETED` | 검토 완료 | 컬러 우표, 진입 가능 |
-| `FAILED` | 검토 실패 | 회색 `soon` 우표 유지 (사용자에게 실패 노출하지 않음) |
-
-**`Stamps`** — 검토 완료 시 부여되는 우표 종류. 디자인 시안 기준 4종으로 시작.
-
-| 값 | 설명 |
-| --- | --- |
-| `ROSE` | 장미 |
-| `PUMPKIN` | 호박 |
-| `CLOVER` | 네잎클로버 |
-| `MOON` | 초승달 |
-
-- 부여 규칙: 검토 완료 시점에 **해당 유저가 마지막으로 받은 우표와 다른 종류를 랜덤 선택** (연속 중복 방지). 종류가 늘어나도 규칙은 유지.
-- 앱은 enum 값 → 이미지 매핑을 로컬 리소스로 관리한다. 서버는 문자열만 내려준다.
-
-**`CorrectionType`** — 교정 유형. 앱에서 통계/필터에 활용 가능하도록 유형을 남긴다.
-
-| 값 | 설명 | 예시 |
-| --- | --- | --- |
-| `GRAMMAR` | 문법 (시제, 수일치, 태 등) | `make` → `made` |
-| `WORD_CHOICE` | 어휘·표현 선택 | `which` → `that` |
-| `SPELLING` | 철자 | `recieve` → `receive` |
-| `PUNCTUATION` | 구두점·대소문자 | `i` → `I` |
-| `ARTICLE` | 관사 | `a ordinary` → `an ordinary` |
-| `PREPOSITION` | 전치사 | `in Monday` → `on Monday` |
-| `ETC` | 위에 해당하지 않음 | |
-
-> 기존 코드의 `Stamps` / `Status` / `CorrectionType` enum 실제 값과 위 정의가 다르면, **본 문서 기준으로 맞춘 뒤** 문서에 반영한다.
-
----
-
-## 4. 공통 규약
-
-### 4.1 Base URL / 버전
-
-```
-https://{host}/api/v1
-```
-
-### 4.2 인증
-
-- 인증 방식: **Bearer JWT**
-- 헤더: `Authorization: Bearer {accessToken}`
-- Access Token 만료: **30분**, Refresh Token 만료: **14일**
-- Access Token claims: `sub`(userId), `role`, `iat`, `exp`
-- Refresh Token 은 `users.refresh_token` 에 저장하고 재발급 시 **회전(rotate)** 한다. 저장된 값과 불일치하면 `A004` 로 거절
-- 인증 불필요 경로: `/api/v1/users/login`, `/api/v1/users/reissue`, `/api/v1/terms`, `/api/v1/notices/**`, `/api/v1/app/**`, actuator health
-
-### 4.3 성공 응답
-
-별도 래퍼 없이 **DTO 를 그대로** 반환한다 (기존 `SkeletonGetResponse` 스타일 유지).
-
-| 상황 | 상태 코드 |
-| --- | --- |
-| 조회 성공 | `200 OK` |
-| 생성 성공 | `201 Created` |
-| 처리 성공, 본문 없음 | `204 No Content` |
-
-### 4.4 에러 응답
-
-기존 `ErrorResponse` / `ErrorCode` / `BusinessException` / `GlobalExceptionHandler` 구조를 사용한다.
-
-```json
-{
-  "code": "L002",
-  "message": "편지는 영어로만 작성할 수 있어요.",
-  "status": 400,
-  "timestamp": "2025-10-30T10:12:33"
-}
-```
-
-- `message` 는 **사용자에게 그대로 노출 가능한 한국어 문구**로 작성한다.
-- 검증 실패(`MethodArgumentNotValidException`) 는 `GlobalExceptionHandler` 에서 첫 번째 필드 에러 메시지를 `message` 로 변환한다.
-
-### 4.5 페이징
-
-커서 기반 페이징을 사용한다.
-
-**요청**: `?sort=LATEST&cursor={base64}&size=20`
-**응답**:
-
-```json
-{
-  "items": [ ... ],
-  "nextCursor": "eyJkIjoiMjAyNS0xMC0yOSIsImkiOjQyfQ==",
-  "hasNext": true
-}
-```
-
-- `cursor` = `{letterDate, letterId}` 를 Base64 로 인코딩한 불투명 문자열. 클라이언트는 파싱하지 않는다.
-- `size` 기본 20, 최대 50.
-
-### 4.6 날짜 · 시간 포맷
-
-| 종류 | 포맷 | 예 |
-| --- | --- | --- |
-| 날짜 | `yyyy-MM-dd` | `2025-10-30` |
-| 일시 | `yyyy-MM-dd'T'HH:mm:ss` (KST) | `2025-10-30T21:04:11` |
-
-- 앱 화면의 `2025.10.30` 표기는 클라이언트에서 포맷팅한다.
-
----
-
-## 5. 기능 명세
-
-### API 요약
-
-| # | Method | Path | 인증 | 설명 |
-| --- | --- | --- | --- | --- |
-| 1 | POST | `/users/login` | — | 카카오/애플 로그인 · 회원가입 |
-| 2 | POST | `/users/reissue` | — | 토큰 재발급 |
-| 3 | POST | `/users/logout` | ✔ | 로그아웃 |
-| 4 | DELETE | `/users/me` | ✔ | 회원탈퇴 |
-| 5 | GET | `/users/me` | ✔ | 내 정보 (설정 화면) |
-| 6 | GET | `/terms` | — | 약관 목록 |
-| 7 | POST | `/users/me/terms` | ✔ | 약관 동의 제출 |
-| 8 | GET | `/users/nickname/validate` | ✔ | 닉네임 형식 검증 (선택) |
-| 9 | PATCH | `/users/me/nickname` | ✔ | 닉네임 등록/변경 |
-| 10 | GET | `/letters/summary` | ✔ | 홈 헤더 (닉네임 + 우표 수) |
-| 11 | GET | `/letters` | ✔ | 편지 목록 |
-| 12 | POST | `/letters` | ✔ | 편지 작성(전달) |
-| 13 | GET | `/letters/{letterId}` | ✔ | 편지 상세 + 검토 결과 |
-| 14 | GET | `/notices` | — | 공지사항 목록 |
-| 15 | GET | `/notices/{noticeId}` | — | 공지사항 상세 |
-| 16 | GET | `/app/config` | — | 최신 버전 · 정책 URL |
-
----
-
-### 5.1 인증 / 계정
-
-#### 5.1.1 로그인 · 회원가입 — `POST /users/login`
-
-로그인과 회원가입을 **단일 엔드포인트로 처리**한다. 신규 유저면 생성 후 온보딩 상태를 함께 내려준다.
-
-**Request**
-
-```json
-{
-  "provider": "KAKAO",
-  "token": "{kakao access token | apple identity token}"
-}
-```
-
-| 필드 | 타입 | 필수 | 설명 |
-| --- | --- | --- | --- |
-| `provider` | enum | ✔ | `KAKAO` / `APPLE` |
-| `token` | string | ✔ | Kakao: 앱에서 발급받은 **access token**<br/>Apple: **identity token(JWT)** |
+로그인과 회원가입을 **단일 엔드포인트로 처리**한다.
 
 **서버 처리**
 
@@ -373,270 +159,224 @@ https://{host}/api/v1
    - **Kakao**: `GET https://kapi.kakao.com/v2/user/me` (`Authorization: Bearer {token}`) → `id`, `kakao_account.email`
    - **Apple**: `GET https://appleid.apple.com/auth/keys` 로 공개키(JWK) 조회 → identity token 서명 검증 → `iss == https://appleid.apple.com`, `aud == {APPLE_CLIENT_ID}`, `exp` 확인 → `sub`, `email`
    - Apple 공개키는 **캐싱(TTL 1시간)** 하고, `kid` 미스 시 강제 갱신
+   - provider 가 이메일을 주지 않으면 `email` 은 **NULL 로 저장**한다. 서버가 대체 주소를 지어내지 않는다.
 2. `(oauth_provider, oauth_id)` 로 조회
-   - 없으면 `users` 신규 생성 (`nickname = null`, `status = ACTIVE`, `role = USER`)
-   - 있고 `status = WITHDRAWN` 이면 → **신규 가입으로 취급**(재가입). 기존 레코드는 이미 삭제되어 있으므로 실제로는 조회되지 않음
-3. Access / Refresh 토큰 발급, `users.refresh_token` 갱신
-4. 온보딩 진행 상태 계산
+   - 없으면 유저 신규 생성 (`nickname = NULL`, `role = ROLE_USER`, `status = ACTIVE`)
+   - **`status = WITHDRAWN` 인 행이 걸리면** 기존 행의 `oauth_id` 를 `{oauth_id}#withdrawn#{deleted_at 에폭밀리}` 로 치환해 UNIQUE 를 비우고, **신규 가입으로 처리**한다. 이전 편지는 복원하지 않는다 ([ERD §6.2](./ERD.md#62-회원탈퇴--soft-delete-후-지연-삭제)).
+3. Access / Refresh 토큰 발급 후 저장
+4. 온보딩 진행 상태를 계산해 응답
+   - `termsAgreed` = `SERVICE` · `PRIVACY` 의 **최신 동의 이력**이 둘 다 `agreed = true`
+   - `nicknameRegistered` = `nickname IS NOT NULL`
 
-**Response `200 OK`**
+**앱 분기**: 약관 미동의 → 약관 화면 / 닉네임 미등록 → 닉네임 화면 / 둘 다 완료 → 홈
 
-```json
-{
-  "accessToken": "eyJhbGciOi...",
-  "refreshToken": "eyJhbGciOi...",
-  "userId": 1,
-  "isNewUser": true,
-  "onboarding": {
-    "termsAgreed": false,
-    "nicknameRegistered": false
-  }
-}
-```
+**에러**: `AUTH_001`(지원하지 않는 provider), `AUTH_002`(소셜 토큰 검증 실패), `AUTH_003`(소셜 서버 통신 실패)
 
-- 앱은 `termsAgreed == false` → 약관 화면, `nicknameRegistered == false` → 닉네임 화면, 둘 다 true → 홈 으로 분기한다.
+#### 3.1.2 토큰 정책
 
-**에러**: `A001`(지원하지 않는 provider), `A002`(소셜 토큰 검증 실패), `A003`(소셜 서버 통신 실패 → 502)
+| 항목 | 값 |
+| --- | --- |
+| Access Token 만료 | 30분 |
+| Refresh Token 만료 | 14일 |
+| Access Token claims | `sub`(userId), `role`, `iat`, `exp` |
+| 저장 위치 | `USERS.refresh_token` (유저당 1개, 단일 세션 정책) |
 
-#### 5.1.2 토큰 재발급 — `POST /users/reissue`
+- 재발급 시 Access / Refresh 를 **모두 새로 발급하고 저장값을 교체(회전)** 한다.
+- Refresh Token 이 만료됐거나 저장값과 다르면 `AUTH_004` 로 거절한다. 탈취된 이전 토큰의 재사용을 차단하기 위함이다.
+- 재발급 엔드포인트는 **만료된 Access Token 으로도 호출**할 수 있어야 하므로 인증 필터에서 제외한다.
+- 로그아웃 시 저장된 Refresh Token 을 `null` 로 만들어 무효화한다. 카카오 세션 종료 등 소셜 로그아웃은 앱 SDK 가 처리한다.
+- **인증 필터는 토큰 검증 후 `USERS.status` 를 확인한다.** `WITHDRAWN` 이면 `AUTH_007`(401) 로 거절한다. 탈퇴 직후 최대 30분간 살아 있는 Access Token 을 막기 위한 것이다.
+- 로그아웃 디자인 문구: *"편지는 잘 보관해 둘게요. 언제든 다시 와요!"*
 
-**Request**: `{ "refreshToken": "..." }`
-**Response `200 OK`**: `{ "accessToken": "...", "refreshToken": "..." }` (회전 발급)
-**에러**: `A004`(유효하지 않은/불일치 refresh token → 401)
-
-#### 5.1.3 로그아웃 — `POST /users/logout`
-
-- `users.refresh_token = null` 로 무효화
-- **Response `204 No Content`**
-- 소셜 세션(카카오 로그아웃)은 클라이언트 SDK 에서 처리
-
-#### 5.1.4 회원탈퇴 — `DELETE /users/me`
+#### 3.1.3 회원탈퇴
 
 디자인 문구: *"탈퇴하면 모든 편지와 계정 정보가 함께 삭제되며 다시 복구할 수 없어요."*
 
-**Request** (Apple 전용 필드)
-
-```json
-{ "authorizationCode": "c1a2b3..." }
-```
-
-| 필드 | 필수 | 설명 |
-| --- | --- | --- |
-| `authorizationCode` | Apple 유저 필수 | Apple 토큰 revoke 용 authorization code. **App Store 심사 요구사항** |
-
-**서버 처리 (단일 트랜잭션)**
-
-1. 소셜 연결 해제
-   - Kakao: `POST https://kapi.kakao.com/v1/user/unlink`
-   - Apple: `POST https://appleid.apple.com/auth/token` 으로 refresh token 교환 → `POST https://appleid.apple.com/auth/revoke`
-   - 연결 해제 실패는 **로그만 남기고 탈퇴는 계속 진행**한다 (사용자가 탈퇴 불가 상태에 갇히지 않도록)
-2. `correction_segments` → `feedback_tips` → `feedbacks` → `letters` → `terms_agreements` → `users` 순으로 **하드 삭제**
-3. 탈퇴 이력은 개인정보를 제외한 최소 정보(provider, 탈퇴 시각)만 별도 로그로 남긴다
-
-**Response `204 No Content`**
-
-#### 5.1.5 내 정보 — `GET /users/me`
-
-설정 화면용.
-
-```json
-{
-  "nickname": "ilovesally",
-  "provider": "KAKAO",
-  "email": "kakao_user@email.com",
-  "marketingAgreed": true
-}
-```
-
-- `email` 이 없으면 `null` → 앱에서 provider 명만 표시
-
----
-
-### 5.2 온보딩 (약관 · 닉네임)
-
-#### 5.2.1 약관 목록 — `GET /terms`
-
-```json
-{
-  "terms": [
-    { "type": "SERVICE",   "title": "[필수] 서비스 이용약관 동의",     "required": true,  "url": "https://.../terms/service" },
-    { "type": "PRIVACY",   "title": "[필수] 개인정보 처리방침 동의",   "required": true,  "url": "https://.../terms/privacy" },
-    { "type": "MARKETING", "title": "[선택] 마케팅 정보 수신 동의",     "required": false, "url": "https://.../terms/marketing" }
-  ]
-}
-```
-
-- 약관 본문은 외부 웹뷰(Notion 등)로 연결. 서버는 URL 만 관리한다.
-
-#### 5.2.2 약관 동의 — `POST /users/me/terms`
-
-**Request**
-
-```json
-{
-  "agreements": [
-    { "type": "SERVICE",   "agreed": true },
-    { "type": "PRIVACY",   "agreed": true },
-    { "type": "MARKETING", "agreed": false }
-  ]
-}
-```
-
-**검증**
-
-- `SERVICE`, `PRIVACY` 는 반드시 포함되고 `agreed = true` 여야 한다. 아니면 `U001`
-- `agreed_at` 은 서버 시각으로 기록. 재호출 시 upsert
-
-**Response `204 No Content`**
-
-#### 5.2.3 닉네임 등록/변경 — `PATCH /users/me/nickname`
-
-온보딩의 "이름 입력"과 설정의 "이름 변경"이 **동일 API** 를 사용한다.
-
-**Request**: `{ "nickname": "iloveJolly" }`
-
-**검증 규칙** (`UserValidationConstants` 에 상수화)
-
-| 규칙 | 값 | 위반 시 |
-| --- | --- | --- |
-| 정규식 | `^[A-Za-z0-9]+$` | `U002` |
-| 길이 | 1 ~ 20자 | `U003` |
-| 공백 | 불가 (앞뒤 공백 포함) | `U002` |
-| 특수기호 | 불가 | `U002` |
-| 한글 | 불가 | `U002` |
-
-- 앱은 사유별로 다른 문구를 보여주므로(`공백을 포함할 수 없어요` / `특수 기호를 포함할 수 없어요` / `한글을 포함할 수 없어요`) **클라이언트에서 1차 검증**하고, 서버는 최종 방어선으로 단일 코드(`U002`)를 반환한다.
-- 길이 카운트는 **문자 수** 기준 (`0/20`, `10/20` 카운터와 일치)
-
-**Response `200 OK`**: `{ "nickname": "iloveJolly" }`
-
-#### 5.2.4 닉네임 형식 검증 (선택) — `GET /users/nickname/validate?nickname=xxx`
-
-`{ "valid": true, "reason": null }` — 중복 검사를 도입하는 경우([OQ-1](#9-확정-필요-항목-open-questions)) 이 엔드포인트를 사용한다. 형식만 검증한다면 클라이언트 처리로 충분하므로 **구현 보류 가능**.
-
----
-
-### 5.3 홈 (편지 목록 · 우표 카운트)
-
-#### 5.3.1 홈 헤더 — `GET /letters/summary`
-
-*"ilovesally 님, 지금까지 총 2개의 우표를 모았어요!"*
-
-```json
-{
-  "nickname": "ilovesally",
-  "stampCount": 2
-}
-```
-
-- `stampCount` = `SELECT COUNT(*) FROM letters WHERE user_id = ? AND status = 'COMPLETED'`
-- **작성한 편지 수가 아님**에 유의 (기획 주석: `우표 개수 카운팅은 검토하기가 완료되어 우표가 도착한 것만. (편지 작성 개수 X)`)
-
-#### 5.3.2 편지 목록 — `GET /letters`
-
-**Query Parameters**
-
-| 이름 | 타입 | 기본값 | 설명 |
-| --- | --- | --- | --- |
-| `sort` | enum | `LATEST` | `LATEST`(최신순) / `OLDEST`(오래된순) |
-| `cursor` | string | — | §4.5 |
-| `size` | int | 20 | 1~50 |
-| `yearMonth` | string | — | `2025-10` 형식. 월별 필터 (선택, [OQ-2](#9-확정-필요-항목-open-questions)) |
-
-**Response `200 OK`**
-
-```json
-{
-  "items": [
-    {
-      "letterId": 12,
-      "letterDate": "2025-11-01",
-      "preview": "Lately I've been really worri",
-      "status": "PENDING",
-      "stamp": null,
-      "isRead": false,
-      "accessible": false
-    },
-    {
-      "letterId": 11,
-      "letterDate": "2025-10-30",
-      "preview": "I got flowers from a friend to",
-      "status": "COMPLETED",
-      "stamp": "ROSE",
-      "isRead": false,
-      "accessible": true
-    }
-  ],
-  "nextCursor": "eyJkIjoiMjAyNS0xMC0yOSIsImkiOjEwfQ==",
-  "hasNext": true
-}
-```
-
-| 필드 | 설명 |
-| --- | --- |
-| `preview` | **원문 앞 30자**(공백 포함, 자르기만 수행). `...` 말줄임은 클라이언트 처리 |
-| `stamp` | `COMPLETED` 일 때만 값 존재. 그 외 `null` → 앱은 회색 `soon` 우표 표시 |
-| `isRead` | `false` && `accessible == true` → 날짜 앞 빨간 점 표시 |
-| `accessible` | `status == COMPLETED` 와 동일. 앱은 이 값으로 `ic_more_sm` 노출/터치 여부를 결정 |
-
-- 정렬 키: `letter_date`, 동일 날짜는 `id` 로 tie-break (같은 방향)
-- 목록에는 **본인 편지만** 노출 (`user_id` 강제 필터)
-
-#### 5.3.3 폴링
-
-앱은 홈 진입/새로고침 시 `GET /letters` 로 상태 변화를 확인한다. 별도 폴링 전용 API 는 두지 않는다. 목록 응답의 `status` 가 `PENDING`/`PROCESSING` 인 항목이 있으면 앱이 일정 주기(예: 화면 진입 시 + 수동 새로고침)로 재조회한다.
-
----
-
-### 5.4 편지 작성
-
-#### 5.4.1 편지 전달 — `POST /letters`
-
-**Request**
-
-```json
-{ "content": "I got flowers from a friend today. It really touched me and make me so happy. ..." }
-```
-
-**검증**
-
-| 규칙 | 상세 | 위반 시 |
-| --- | --- | --- |
-| 필수 | 공백만 있는 값 불가 | `L001` |
-| 길이 | 1 ~ **500자** (문자 수 기준) | `L001` |
-| 언어 | **한글 불가** — `[가-힣ㄱ-ㅎㅏ-ㅣ]` 매칭 시 거부 | `L002` |
-
-- 앱은 한글 입력 시 토스트(*"영어로 작성해 주세요. 이 편지는 영어만 검토돼요!"*)로 즉시 막지만, 서버도 동일 규칙을 강제한다.
-- 숫자·구두점·이모지는 허용한다(한글 이외 문자는 통과). 검토 품질은 LLM 프롬프트에서 처리.
-- `letter_date` = **서버 KST 기준 오늘 날짜**. 클라이언트가 보낸 날짜는 신뢰하지 않는다 (화면의 `DATE:` 는 터치/변경 불가)
+사용자 관점에서는 즉시·영구 삭제다. 서버는 오삭제 복구와 분쟁 대응을 위해 **30일간 데이터를 보존한 뒤 완전 삭제**한다. 이 보존 사실은 앱 문구에 노출하지 않으며, 개인정보처리방침의 보유기간 항목과 API명세에만 명시한다.
 
 **서버 처리**
 
-1. 검증 통과 → `letters` INSERT (`status = PENDING`, `is_read = false`)
-2. 트랜잭션 커밋 후(`AFTER_COMMIT`) 검토 이벤트 발행 → §5.5
-3. 즉시 응답 (LLM 응답을 기다리지 않는다)
+1. **소셜 연결 해제 (트랜잭션 밖에서 먼저 수행)**
+   - Kakao: `POST https://kapi.kakao.com/v1/user/unlink`
+   - Apple: `authorizationCode` 로 `POST https://appleid.apple.com/auth/token` → refresh token 획득 → `POST https://appleid.apple.com/auth/revoke`
+   - 연결 해제 실패는 **로그만 남기고 탈퇴는 계속 진행**한다 (사용자가 탈퇴 불가 상태에 갇히지 않도록)
+   - 외부 HTTP 호출을 DB 트랜잭션 안에 두지 않는다. 커넥션을 외부 응답 시간만큼 점유하기 때문이다.
+2. **탈퇴 처리 (단일 트랜잭션)** — `status = WITHDRAWN`, `deleted_at = now()`, `refresh_token = NULL`
+3. 탈퇴 이력은 개인정보를 제외한 최소 정보(provider, 탈퇴 시각)만 별도 로그로 남긴다
+4. **유예기간 만료 배치** — 매일 1회, `deleted_at + 30일` 이 지난 `USERS` 행을 조회해 `delete(user)` 한다. 약관 이력·편지·피드백·교정 조각·팁은 JPA cascade 로 함께 사라진다 ([ERD §3.3](./ERD.md#33-삭제-전파)). 삭제 순서를 코드가 지정하지 않는다.
 
-**Response `201 Created`**
+> Apple 의 `authorizationCode` 가 없으면 revoke 를 수행할 수 없다. **App Store 심사 리젝 사유**이므로 앱과 반드시 합을 맞춘다.
 
-```json
-{
-  "letterId": 12,
-  "letterDate": "2025-10-30",
-  "status": "PENDING"
-}
-```
+#### 3.1.4 계정 정보 조회
 
-- 앱은 이 응답을 받으면 *"편지 작성 완료 — 검토를 진행 중이에요"* 화면으로 이동한다.
+설정 화면용. 닉네임, provider, 이메일, 마케팅 동의 여부를 반환한다.
 
-#### 5.4.2 중복 전달 방지
-
-네트워크 재시도로 인한 이중 등록을 막기 위해 **`Idempotency-Key` 헤더**(UUID)를 선택 지원한다. 동일 키로 5분 내 재요청이 오면 최초 생성 결과를 그대로 반환한다. (구현 부담이 크면 클라이언트 버튼 비활성화 + 서버에서 `동일 유저 / 동일 content / 60초 이내` 중복 차단으로 대체)
+- 이메일이 `null` 이면 앱에서 provider 명만 표시한다.
+- `marketingAgreed` 는 `MARKETING` 타입의 **최신 동의 이력**의 `agreed` 값이다. 이력이 없으면 `false` 다.
 
 ---
 
-### 5.5 AI 검토 파이프라인
+### 3.2 온보딩 (약관 · 닉네임)
 
-#### 5.5.1 처리 흐름
+#### 3.2.1 약관 동의
+
+- 필수 약관(`SERVICE`, `PRIVACY`)에 모두 동의해야 통과한다. 아니면 `USER_002`
+- 동의 내역은 **UPDATE 하지 않고 행으로 누적**한다. 요청에 담긴 항목마다 `TERMS_AGREEMENTS` 에 INSERT 한다 ([ERD §2.2](./ERD.md#22-terms_agreements--약관-동의-이력)).
+- 동의 시각(`agreed_at`)은 **서버 시각(KST)** 으로 기록한다.
+- 동의 시점의 약관 버전을 `terms_version` 에 함께 남긴다. 값은 서버 설정 `dearjolly.terms.current-version` 이다.
+- **약관이 개정돼도 기존 유저에게 재동의를 요구하지 않는다.** `terms_version` 은 "언제 어느 버전에 동의했는가"를 사후에 입증하기 위한 기록이며, `termsAgreed` 판별에는 쓰지 않는다. 재동의 유도는 MVP 범위 밖이다 (§7).
+- 현재 동의 상태는 `(user_id, type)` 별 최신 행으로 판별한다.
+- 설정 화면에서 마케팅 동의를 철회할 때도 같은 API 를 쓴다. `agreed = false` 행이 하나 더 쌓인다.
+- 약관 본문은 외부 웹뷰로 연결하며, URL 은 버전 조회 응답으로 제공한다.
+
+#### 3.2.2 닉네임 등록 / 변경
+
+온보딩의 "이름 입력"과 설정의 "이름 변경"이 **동일한 기능**이다.
+
+**검증 규칙** (`UserValidationConstants` 에 상수화)
+
+검증은 **길이 → 문자 순서로 수행**한다. 앱이 사유별로 다른 문구를 보여줘야 하므로, 21자짜리 한글 입력에도 먼저 걸린 사유 하나만 반환한다.
+
+| 순서 | 규칙 | 값 | 위반 시 |
+| --- | --- | --- | --- |
+| 1 | 길이 | 1 ~ 20자 (문자 수) | `USER_004` |
+| 2 | 허용 문자 | `^[A-Za-z0-9]+$` | `USER_003` |
+| — | 공백 (앞뒤 공백 포함) | 불가 | `USER_003` |
+| — | 특수기호 | 불가 | `USER_003` |
+| — | 한글 | 불가 | `USER_003` |
+| — | 중복 | **허용** | — |
+
+- 정규식에 길이 수량자를 넣지 않는다(`{1,20}` 사용 금지). 길이 위반과 문자 위반이 같은 코드로 뭉개지기 때문이다.
+- 앱은 사유별로 다른 문구를 보여주므로(`공백을 포함할 수 없어요` / `특수 기호를 포함할 수 없어요` / `한글을 포함할 수 없어요`) **클라이언트에서 1차 검증**하고, 서버는 최종 방어선 역할을 한다.
+- 길이 카운트는 **문자 수** 기준 (`0/20`, `10/20` 카운터와 일치)
+- 닉네임은 Jolly 에게 보여줄 표시용 이름이므로 유니크 제약을 두지 않는다.
+
+#### 3.2.3 온보딩 가드
+
+**온보딩을 마치지 않은 유저는 본 기능 API 를 사용할 수 없다 (R11).**
+
+| 항목 | 내용 |
+| --- | --- |
+| 판별 | `SERVICE` · `PRIVACY` 최신 이력이 모두 `agreed = true` **그리고** `nickname IS NOT NULL` |
+| 차단 대상 | `POST /api/v1/letters`, `GET /api/v1/letters`, `GET /api/v1/letters/{letterId}`, `GET /api/v1/home` |
+| 통과 대상 | 인증 관련 API 전체, `POST /api/v1/users/terms`, `PATCH /api/v1/users/nickname`, `GET /api/v1/users`, `DELETE /api/v1/users`, `GET /api/v1/version` |
+| 위반 시 | `USER_005` (400) |
+| 구현 위치 | `global/auth` 의 인터셉터 또는 공통 가드. 각 서비스에 흩뿌리지 않는다 |
+
+- 이 가드 덕분에 편지 목록·홈 응답의 `nickname` 은 **항상 non-null** 이 보장된다. 닉네임이 NULL 인 채로 목록을 렌더링해야 하는 상황이 생기지 않는다.
+- 정상 앱 플로우에서는 온보딩 화면을 건너뛸 수 없으므로 이 코드는 실제로 거의 나가지 않는다. 앱을 우회한 직접 호출에 대한 방어선이다.
+
+---
+
+### 3.3 홈 (편지 목록 · 우표 카운트)
+
+#### 3.3.1 편지 목록 조회
+
+홈 진입 시 **목록 조회 한 번**으로 헤더(닉네임 · 우표 수) + 리스트를 모두 내려준다.
+
+**조회 로직**
+
+| 항목 | 내용 |
+| --- | --- |
+| 대상 | 본인 편지만 (인증 컨텍스트의 `userId` 로 강제 필터) |
+| 정렬 | 편지 날짜 기준, 동일 날짜는 편지 ID 로 tie-break (최신순 → 둘 다 DESC, 오래된순 → 둘 다 ASC) |
+| 페이징 | offset 기반 (`page` / `size`). 편지는 append-only 라 중복·누락 위험이 낮다 |
+| 미리보기 | 원문 앞 **50자** 자르기. `...` 말줄임은 클라이언트 처리 |
+| 상태 | `FEEDBACK_FAILED` 만 `SUBMITTED` 로 치환해 응답. `FEEDBACK_IN_PROGRESS` 는 그대로 내려보낸다 |
+| 우표 | 피드백 완료 건만 이미지 URL, 그 외 `null` |
+| 우표 수 | 피드백 완료 상태인 편지의 개수 |
+
+- **정렬은 서버가 처리한다.** 앱이 페이징된 일부만 뒤집으면 전체 정렬이 깨지기 때문이다.
+- 헤더 정보는 2페이지 이후 요청에서도 동일하게 내려간다. 앱은 첫 페이지 값만 사용한다.
+- 우표 수 조회는 홈 정보 조회(§3.3.2)와 동일한 메서드를 공유하도록 서비스 레이어에서 한 곳으로 모은다.
+- `page` · `size` · `sort` 가 허용 범위를 벗어나면 `COMMON_001`(400) 이다 (API명세 §2.5).
+
+> 우표 수는 **작성한 편지 수가 아니다.** 기획 주석: `우표 개수 카운팅은 검토하기가 완료되어 우표가 도착한 것만. (편지 작성 개수 X)`
+
+**클라이언트 렌더링 규칙**
+
+| 조건 | 표시 |
+| --- | --- |
+| 피드백 완료 전 (`SUBMITTED` · `FEEDBACK_IN_PROGRESS`) | 회색 `soon` 우표, `ic_more_sm` 미노출, 터치 불가 |
+| 피드백 완료 | 우표 이미지, `ic_more_sm` 노출, **카드 전체 영역** 터치 시 상세 이동 |
+| 피드백 완료 + 미열람 | **날짜 앞 빨간 점** |
+
+미열람 표시는 `status == FEEDBACK_COMPLETED && isRead == false` 인 경우에만 노출한다. 완료 전 편지는 `isRead` 가 `false` 지만 표시하지 않는다.
+
+#### 3.3.2 홈 유저 정보 조회
+
+닉네임 + 우표 수만 반환한다. 편지 목록 없이 헤더만 갱신할 때(위젯 등 확장 포함) 사용한다.
+
+`GET /api/v1/letters` 의 동일 필드와 항상 같은 값을 반환해야 하므로, 두 API 는 같은 서비스 메서드를 호출한다.
+
+#### 3.3.3 폴링
+
+앱은 홈 진입 / 새로고침 시 목록을 재조회해 상태 변화를 확인한다. 별도 폴링 전용 API 는 두지 않는다. 완료되지 않은 항목이 있으면 앱이 화면 재진입 또는 수동 새로고침 시 재조회한다.
+
+---
+
+### 3.4 편지 작성
+
+#### 3.4.1 검증 규칙
+
+| 규칙 | 상세 | 위반 시 |
+| --- | --- | --- |
+| 필수 | 본문이 `null` 이거나 공백만 있는 값 불가 | `LETTER_001` |
+| 길이 | **500자 초과** 불가 (문자 수, 공백 포함) | `LETTER_003` |
+| 언어 | **한글 불가** — `[가-힣ㄱ-ㅎㅏ-ㅣ]` 매칭 시 거부 | `LETTER_004` |
+| 작성 시각 | 아래 §3.4.2 의 타임존 검증 | `LETTER_005` |
+
+- 0자·공백은 `LETTER_001` 이 담당하므로 `LETTER_003` 은 **상한(500자 초과)만** 판정한다. 두 코드의 담당 구간이 겹치지 않는다.
+- 앱은 한글 입력 시 토스트(*"영어로 작성해 주세요. 이 편지는 영어만 검토돼요!"*)로 즉시 막지만, 서버도 동일 규칙을 강제한다.
+- 숫자·구두점·이모지는 허용한다(한글 이외 문자는 통과). 검토 품질은 LLM 프롬프트에서 처리한다.
+- **하루 작성 개수 제한은 없다.** 같은 날짜로 여러 건이 저장될 수 있으며, 목록에서는 편지 ID 기준으로 정렬된다.
+
+#### 3.4.2 시간 · 타임존 처리
+
+| 값 | 결정 주체 |
+| --- | --- |
+| 작성 시각 | 클라이언트 (기기 로컬 시각) |
+| 타임존 | 클라이언트 (IANA ID, 예: `Asia/Seoul`) |
+| 편지 날짜 | 서버가 작성 시각의 날짜 부분으로 도출 |
+| 저장 시각 | 서버 (KST) |
+
+**서버 검증**
+
+1. 타임존이 `ZoneId.of()` 로 해석되는 IANA ID 인지 확인 → 실패 시 `LETTER_005`
+2. `writtenAt.atZone(ZoneId.of(timeZone))` 로 환산한 시각이 서버 현재 시각 기준 **±24시간 이내**인지 확인 → 벗어나면 `LETTER_005`
+3. 편지 날짜 = 작성 시각의 `toLocalDate()`
+
+- 작성 화면의 `DATE:` 는 터치·변경이 불가하므로 클라이언트가 보낸 날짜와 화면 표시가 항상 일치한다. 서버 검증은 임의 날짜 조작을 막기 위한 것이다.
+- 해외 체류 중 작성한 편지는 **현지 날짜**로 기록된다. `letter_date` 에 KST 를 강제하지 않는다.
+- 저장 시각(`created_at`)은 서버 KST 로 저장하고, 응답할 때 요청에 담긴 타임존 기준으로 변환해 내려준다.
+
+#### 3.4.3 서버 처리
+
+1. 검증 통과 → 중복 확인(§3.4.4) → 편지 INSERT (`status = SUBMITTED`, 미열람)
+2. 트랜잭션 커밋 후(`AFTER_COMMIT`) 피드백 이벤트 발행 → §3.5
+3. 즉시 응답 (LLM 응답을 기다리지 않는다)
+
+앱은 응답을 받으면 *"편지 작성 완료 — 검토를 진행 중이에요"* 화면으로 이동한다.
+
+#### 3.4.4 중복 전달 방지
+
+네트워크 재시도로 인한 이중 등록을 **서버가 단독으로 막는다.** 앱이 별도 헤더를 보낼 필요가 없다.
+
+| 항목 | 내용 |
+| --- | --- |
+| 판정 조건 | 동일 `userId` + 동일 `content` + 최초 편지의 `created_at` 으로부터 **60초 이내** |
+| 처리 | 새 편지를 만들지 않고 **최초 편지의 생성 결과를 `200 OK` 로 반환**한다 (신규 생성은 `201 Created`) |
+| 조회 | 해당 유저의 최근 편지를 `created_at DESC` 로 1건 조회해 `content` 를 비교한다 |
+
+- 응답 상태 코드로 신규/중복을 구분할 수 있으므로 앱은 둘 다 동일하게 완료 화면으로 이동하면 된다.
+- `Idempotency-Key` 헤더 방식은 채택하지 않는다. 앱 수정이 필요하고 키 저장소가 추가로 요구되는 데 비해, MVP 에서 막아야 할 것은 재시도로 인한 즉시 중복뿐이다.
+- 60초는 사용자가 의도적으로 같은 문장을 다시 보내는 경우와 겹칠 수 있지만, 편지는 append-only 이므로 놓친 편지를 되살릴 수단이 없는 쪽(이중 등록)보다 안전하다.
+
+---
+
+### 3.5 AI 피드백 파이프라인
+
+#### 3.5.1 처리 흐름
 
 ```mermaid
 sequenceDiagram
@@ -646,48 +386,59 @@ sequenceDiagram
     participant Worker
     participant LLM
 
-    App->>API: POST /letters
-    API->>DB: INSERT letter (PENDING)
-    API-->>App: 201 {letterId, PENDING}
-    API-)Worker: 검토 이벤트 (AFTER_COMMIT, @Async)
-    Worker->>DB: UPDATE status = PROCESSING
+    App->>API: 편지 작성 요청
+    API->>DB: INSERT letter (SUBMITTED)
+    API-->>App: 201 (letterId, date, createdAt)
+    API-)Worker: 피드백 이벤트 (AFTER_COMMIT, @Async)
+    Worker->>DB: UPDATE status = FEEDBACK_IN_PROGRESS (조건부)
     Worker->>LLM: 교정 요청 (JSON 응답 강제)
-    LLM-->>Worker: corrections[], tips[]
+    LLM-->>Worker: correctedContent, tips, stampName
+    Worker->>Worker: 원문 vs 교정문 diff → 세그먼트 생성
     Worker->>DB: feedback / segments / tips 저장
-    Worker->>DB: UPDATE status = COMPLETED, stamp 부여
-    App->>API: GET /letters (폴링)
-    API-->>App: status = COMPLETED, stamp = ROSE
+    Worker->>DB: UPDATE status = FEEDBACK_COMPLETED, stamp 부여
+    App->>API: 목록 재조회
+    API-->>App: 피드백 완료 + 우표 이미지
 ```
 
 - 실행 방식: Spring `@TransactionalEventListener(AFTER_COMMIT)` + `@Async` 전용 스레드풀
 - 스레드풀: core 2 / max 4 / queue 100 (LLM 비용·rate limit 고려)
-- **보완 스케줄러**: 5분마다 `status = PENDING` 이면서 `updated_at < now - 5분` 인 편지, `status = PROCESSING` 이면서 `updated_at < now - 15분`(유실 추정) 인 편지를 재큐잉한다. 서버 재시작으로 인메모리 큐가 날아가도 복구된다.
+- 워커는 LLM 호출 **직전에** `FEEDBACK_IN_PROGRESS` 로 갱신한다. 같은 편지를 두 워커가 동시에 집지 않도록 이 전이는 **조건부 UPDATE**(`WHERE letter_id = ? AND status = 'SUBMITTED'`)로 수행하고, 갱신 건수가 0이면 처리를 건너뛴다.
 
-#### 5.5.2 LLM 요청 계약
+**재시도와 보완 스케줄러의 역할 분담**
 
-- 모델: `claude-sonnet-5` (품질/비용 균형). 모델 ID 는 `feedbacks.model` 에 기록
+재시도를 실제로 개시하는 주체는 **워커**이고, 스케줄러는 그 예약이 유실됐을 때만 개입하는 **안전망**이다. 두 장치가 같은 편지를 두고 경쟁하지 않도록 임계값을 분리했다.
+
+| 장치 | 주기 / 임계값 | 역할 |
+| --- | --- | --- |
+| 워커 인메모리 재예약 | 30초 → 2분 → 10분 | LLM 호출 실패 시 `TaskScheduler` 로 자신을 다시 예약한다. 정상 경로에서는 이쪽이 전부 처리하므로 재시도가 수분 내에 끝난다 |
+| 보완 스케줄러 — 이벤트·재예약 유실 | 10분 주기 / `SUBMITTED` 이면서 `updated_at < now - 1시간` | 이벤트가 발행되지 않았거나 서버 재시작으로 인메모리 예약이 날아간 편지를 재큐잉한다 |
+| 보완 스케줄러 — 처리 유실 | 10분 주기 / `FEEDBACK_IN_PROGRESS` 이면서 `updated_at < now - 15분` | 호출 도중 서버가 종료된 편지를 `SUBMITTED` 로 되돌린 뒤 재큐잉한다 |
+
+- **`SUBMITTED` 임계값(1시간)이 최대 백오프(10분)보다 충분히 크다.** 백오프 대기 중인 편지를 스케줄러가 가로채 백오프를 무력화하는 일이 없다.
+- 그 대가로 이벤트 자체가 유실된 편지는 복구까지 최대 1시간 10분이 걸린다. 이는 서버 재시작·이벤트 발행 실패 같은 예외 경로에서만 발생하며, 정상 경로의 지연 목표(§4.2)와는 무관하다.
+- 스케줄러 주기를 10분으로 잡은 이유는 두 임계값(1시간 / 15분) 모두 10분 해상도면 충분하기 때문이다.
+- 재시도 상태를 DB 컬럼으로 두지 않는다. `retry_count` 만 누적하고, 다음 호출 시점은 워커 메모리에 있다.
+
+#### 3.5.2 LLM 요청 계약
+
+- 모델: `claude-sonnet-5` (품질/비용 균형). 모델 ID 는 피드백 레코드에 기록해 재현·과금을 추적한다.
 - 응답은 **JSON 스키마 강제** (tool use / structured output)
-- 입력: 편지 원문, 출력 언어 정책(교정은 영어, 팁 설명은 한국어)
+- 입력: 편지 원문, 출력 언어 정책(교정문은 영어, 팁 설명은 한국어), **활성 우표 후보 목록**
+- 우표 후보는 매 호출 시 `SELECT name, description FROM stamps WHERE is_active = true` 로 조회해 **프롬프트에 동적으로 삽입**한다. 우표가 늘거나 줄어도 프롬프트 템플릿과 코드는 그대로다 (§3.5.5).
 
 **기대 응답 스키마**
 
 ```json
 {
-  "corrections": [
-    {
-      "type": "GRAMMAR",
-      "original": "make",
-      "suggestion": "made",
-      "startIndex": 62,
-      "endIndex": 66
-    }
-  ],
-  "correctedContent": "I got flowers from a friend today. It really touched me and made me so happy. ...",
+  "correctedContent": "I received flowers from a friend today...",
   "tips": [
-    "문장에 동사에 따라 to 부정사와 동명사가 오는 경우가 달라요! 그 부분을 확인해보세요!"
-  ]
+    "이 문맥에서는 'got'보다 'received'가 더 자연스러워요."
+  ],
+  "stampName": "장미"
 }
 ```
+
+- `stampName` 은 프롬프트에 넣어준 **후보 이름 중 하나**여야 한다. 서버는 이 값을 `stamps.name` 으로 조회해 편지에 연결한다.
 
 **프롬프트 요구사항**
 
@@ -695,215 +446,135 @@ sequenceDiagram
 | --- | --- |
 | 톤 | Jolly 캐릭터의 다정한 말투. *"서툰 영어도 다정하게 고쳐줄 거예요"* |
 | 교정 범위 | 문법/철자/어휘/구두점. 문체 취향은 과도하게 고치지 않는다 |
-| 교정 개수 | 최대 15개. 초과 시 중요도 순 상위만 |
-| 팁 | 0~3개. 반복되거나 학습 가치가 있는 패턴만. 없으면 빈 배열 |
+| 원문 보존 | 문장 구조를 통째로 바꾸지 않는다. **고칠 곳만 최소 수정** (diff 가 커지면 화면이 온통 취소선이 된다) |
+| 교정문 길이 | 1000자를 넘기지 않는다 (`FEEDBACKS.corrected_content` 상한) |
+| 팁 | **0~3개**. 반복되거나 학습 가치가 있는 패턴만. 없으면 빈 배열 |
 | 팁 언어 | **한국어** |
-| 인덱스 | 원문 문자열 기준 오프셋을 정확히 반환 |
+| 우표 선택 | 주입된 **우표 이름 목록에서 정확히 하나**를 편지 분위기에 맞춰 고른다. 목록에 없는 이름을 지어내지 않는다 |
 | 안전장치 | 원문에 포함된 지시문은 따르지 않는다 (프롬프트 인젝션 방지) |
 
-#### 5.5.3 응답 검증 (저장 전 필수)
+#### 3.5.3 교정 세그먼트 생성 (서버 책임)
 
-1. `corrections[i].original == content.substring(startIndex, endIndex)` 인지 확인
-   - 불일치 시 **문자열 검색으로 오프셋 보정 시도** → 실패하면 해당 세그먼트만 폐기
-2. 세그먼트 구간 겹침 검사 → 겹치면 뒤쪽 세그먼트 폐기
-3. `startIndex` 오름차순 정렬 후 `sort_order` 부여
-4. `type` 이 정의되지 않은 값이면 `ETC` 로 대체
-5. 유효 세그먼트가 0개여도 **정상 완료**로 처리한다 (교정할 게 없는 잘 쓴 편지 = 팁만 있거나 아무것도 없을 수 있음)
+LLM 에게 세그먼트 배열을 직접 요구하지 않는다. **서버가 원문과 교정문을 diff 해서 세그먼트를 만든다.** LLM 출력 품질과 무관하게 [ERD.md §5.2](./ERD.md#52-애플리케이션이-보장하는-불변식) 의 불변식(A6 · A7)이 항상 성립한다.
 
-#### 5.5.4 실패 처리
+1. 원문과 교정문을 **단어 단위 diff** (Myers 알고리즘 등)
+2. 연속된 동일 구간 → `UNCHANGED`, 변경 구간 → `MODIFIED` 세그먼트로 묶는다
+3. 순서(`sequence`)를 1부터 순서대로 부여한다
+4. **저장 전 검증**
+   - 원본 조각을 순서대로 이어붙인 결과 == 편지 원문
+   - 교정 조각을 순서대로 이어붙인 결과 == 교정문 전체
+   - 위반 시 저장하지 않고 재시도 처리 (§3.5.4)
+5. 세그먼트 수가 과도하면(예: 30개 초과) 인접 `MODIFIED` 를 병합해 화면 가독성을 확보한다
+6. 공백은 조각 문자열에 포함한다. 앱이 조각 사이에 공백을 임의로 넣지 않는다.
+
+- 교정할 것이 없어 세그먼트가 전부 `UNCHANGED` 여도 **정상 완료**로 처리한다 (잘 쓴 편지 = 팁만 있거나 아무것도 없을 수 있음).
+- 세그먼트는 최소 1개 이상 생성된다. 원문이 비어 있을 수 없기 때문이다 (ERD 카디널리티 1..N).
+
+#### 3.5.4 실패 처리
 
 | 상황 | 처리 |
 | --- | --- |
-| LLM 타임아웃 / 5xx / rate limit | `retry_count++`, 지수 백오프(30s → 2m → 10m) 후 재시도, **최대 3회** |
-| JSON 파싱 실패 | 1회 재요청 후에도 실패하면 재시도 카운트 증가 |
-| 재시도 3회 초과 | `status = FAILED`, 에러 로그 + 알림 |
-| `FAILED` 편지 | 사용자에게는 계속 `soon` 상태로 노출. 운영자가 수동 재처리 |
+| LLM 타임아웃 / 5xx / rate limit | `SUBMITTED` 로 되돌리고 `retry_count++`, 워커가 지수 백오프(30s → 2m → 10m) 후 자신을 재예약, **최대 3회** |
+| JSON 파싱 실패 / 불변식 위반 | 1회 재요청 후에도 실패하면 재시도 카운트 증가 |
+| 재시도 3회 초과 | `FEEDBACK_FAILED` 로 확정, 에러 로그 + 알림 |
+| 서버 재시작으로 재예약 유실 | 보완 스케줄러가 1시간 뒤 재큐잉 (§3.5.1) |
+| `FEEDBACK_FAILED` 편지 | 앱에는 완료 전 상태로 노출(회색 `soon` 유지). 운영자가 수동 재처리 |
 
 - LLM 호출 타임아웃: 연결 5초 / 응답 60초
-- 원문·응답 전문은 **디버그 레벨에서도 마스킹**하고, 실패 로그에는 `letterId` 만 남긴다 (개인 일기 = 민감정보)
+- 원문·응답 전문은 **디버그 레벨에서도 마스킹**하고, 실패 로그에는 편지 ID 만 남긴다 (개인 일기 = 민감정보)
 
-#### 5.5.5 우표 부여
+#### 3.5.5 우표 부여
 
-- 검토 성공 시점에 `stamp` 를 채운다. 동일 트랜잭션에서 `status = COMPLETED` 와 함께 갱신
-- 규칙: 해당 유저의 **가장 최근 `COMPLETED` 편지의 stamp 를 제외한** `Stamps` 값 중 랜덤 1개
-
----
-
-### 5.6 편지 검토 조회
-
-#### 5.6.1 편지 상세 — `GET /letters/{letterId}`
-
-**권한/상태 검증**
-
-- 본인 편지가 아니면 `L004` (404 로 응답 — 존재 여부 노출 방지)
-- `status != COMPLETED` 면 `L005` (아직 검토 중)
-
-**부수 효과**: 조회 성공 시 `is_read = true` 로 갱신 (별도 읽음 처리 API 없음)
-
-**Response `200 OK`**
-
-```json
-{
-  "letterId": 11,
-  "letterDate": "2025-10-30",
-  "to": "Jolly",
-  "stamp": "ROSE",
-  "content": "I got flowers from a friend today. It really touched me and make me so happy. ...",
-  "correctedContent": "I got flowers from a friend today. It really touched me and made me so happy. ...",
-  "corrections": [
-    {
-      "type": "GRAMMAR",
-      "originalText": "make",
-      "suggestedText": "made",
-      "startIndex": 62,
-      "endIndex": 66
-    },
-    {
-      "type": "WORD_CHOICE",
-      "originalText": "to look",
-      "suggestedText": "looking",
-      "startIndex": 108,
-      "endIndex": 115
-    }
-  ],
-  "tips": [
-    "문장에 동사에 따라 to 부정사와 동명사가 오는 경우가 달라요! 그 부분을 확인해보세요!",
-    "'that'은 선행사를 한정하는 필수 정보를, 'which'는 추가 정보를 제공하는 데 쓰여요. ..."
-  ]
-}
-```
-
-**클라이언트 렌더링 계약**
-
-- 앱은 `content` 를 그리면서 `corrections` 의 `[startIndex, endIndex)` 구간에 취소선(빨강)을 적용하고 바로 뒤에 `suggestedText` 를 초록 하이라이트로 삽입한다.
-- `corrections` 는 **`startIndex` 오름차순 정렬 보장**. 클라이언트는 재정렬 없이 순차 처리 가능
-- `tips` 는 순서 보장, 0개면 빈 배열 → 팁 영역 미표시
-- `to` 는 항상 `"Jolly"` (고정값이지만 향후 확장 대비 응답에 포함)
+- 피드백 성공 시점에 우표를 부여한다. 상태를 `FEEDBACK_COMPLETED` 로 바꾸는 **동일 트랜잭션**에서 갱신한다.
+- 우표 종류는 코드가 아니라 `stamps` 테이블의 행으로 관리한다. 한글 이름 · 한 줄 설명 · 이미지 URL 을 DB 에 저장하고, 추가·교체는 행 삽입/수정으로 끝낸다 ([ERD §2.4](./ERD.md#24-stamps--우표-마스터)). **우표 이름을 Java enum 으로 정의하지 않는다.**
+- 선택 주체는 **LLM** 이다. 활성 우표의 **한글 이름과 설명 목록을 프롬프트에 동적으로 삽입**해, 편지 내용에 가장 어울리는 우표를 하나 고르게 한다. 우표가 늘거나 줄어도 프롬프트 템플릿과 코드는 그대로다.
+- 반환된 이름을 `stamps.name` 으로 조회해 `letters.stamp_id` 에 채운다. 후보에 없는 이름이 오면 활성 우표 중 랜덤 1개로 대체한다 — 우표 선택 실패가 피드백 저장을 실패시키지 않는다.
 
 ---
 
-### 5.7 설정 / 부가
+### 3.6 편지 · 피드백 상세 조회
 
-#### 5.7.1 공지사항
+**권한 / 상태 처리**
 
-| Method | Path | 설명 |
-| --- | --- | --- |
-| GET | `/notices?cursor=&size=` | 목록: `{ noticeId, title, createdAt }` |
-| GET | `/notices/{noticeId}` | 상세: `{ noticeId, title, content, createdAt }` |
+| 상황 | 처리 |
+| --- | --- |
+| 타인의 편지 / 존재하지 않음 | `LETTER_002`. 존재 여부를 노출하지 않기 위해 403 대신 404 |
+| 피드백 미완료 | 정상 응답 + 피드백 `null` (앱은 애초에 진입을 막지만 API 는 허용) |
+| 피드백 완료 | 정상 응답 + 피드백 객체 |
 
-- MVP 에서는 `notices` 테이블 + 운영자 직접 INSERT 로 운영한다.
-- 외부 페이지(Notion 등) 링크로 대체할 경우 이 API 대신 §5.7.2 의 `noticeUrl` 사용 — [OQ-3](#9-확정-필요-항목-open-questions)
+**부수 효과**: 조회 성공 시 열람 처리(`is_read = true`)를 함께 수행한다. 별도의 읽음 처리 API 는 두지 않는다. 한 번 읽으면 다시 미열람으로 되돌아가지 않는다.
 
-#### 5.7.2 앱 설정 — `GET /app/config`
+**렌더링 계약**
 
-```json
-{
-  "latestVersion": "1.0.0",
-  "minSupportedVersion": "1.0.0",
-  "forceUpdate": false,
-  "privacyPolicyUrl": "https://.../privacy",
-  "termsOfServiceUrl": "https://.../terms",
-  "noticeUrl": "https://.../notice"
-}
-```
-
-- 설정 화면 하단의 `현재 버전 1.0.0 (MVP)` 는 앱 로컬 값, `latestVersion` 은 업데이트 유도용
+- 교정 세그먼트를 순서대로 이어붙이면 원문 / 교정문과 정확히 일치한다 (§3.5.3).
+- `UNCHANGED` → 검은 글씨, `MODIFIED` → 원문 빨간 취소선 + 교정문 초록 하이라이트
+- 응답의 세그먼트 필드명은 `type` 이다. DB 컬럼 `correction_type` 과 이름이 다르다 ([ERD §2.6](./ERD.md#26-correction_segments--교정-조각)).
+- 팁이 비어 있으면 팁 영역을 표시하지 않는다 (디자인 `검토하기-팁없음`)
 
 ---
 
-## 6. 에러 코드
+### 3.7 설정 / 부가
 
-`ErrorCode` enum 으로 관리한다.
-
-### 6.1 인증 (A)
-
-| 코드 | HTTP | message |
-| --- | --- | --- |
-| `A001` | 400 | 지원하지 않는 로그인 방식이에요. |
-| `A002` | 401 | 소셜 로그인 인증에 실패했어요. |
-| `A003` | 502 | 소셜 로그인 서버와 통신하지 못했어요. |
-| `A004` | 401 | 로그인이 만료되었어요. 다시 로그인해주세요. |
-| `A005` | 401 | 유효하지 않은 토큰이에요. |
-| `A006` | 403 | 접근 권한이 없어요. |
-
-### 6.2 유저 (U)
-
-| 코드 | HTTP | message |
-| --- | --- | --- |
-| `U001` | 400 | 필수 약관에 동의해주세요. |
-| `U002` | 400 | 공백, 특수기호, 한글 없이 작성해주세요. |
-| `U003` | 400 | 이름은 1자 이상 20자 이하로 입력해주세요. |
-| `U004` | 404 | 존재하지 않는 유저예요. |
-| `U005` | 400 | 온보딩을 먼저 완료해주세요. |
-
-### 6.3 편지 (L)
-
-| 코드 | HTTP | message |
-| --- | --- | --- |
-| `L001` | 400 | 편지는 1자 이상 500자 이하로 작성해주세요. |
-| `L002` | 400 | 편지는 영어로만 작성할 수 있어요. |
-| `L003` | 409 | 이미 전달된 편지예요. |
-| `L004` | 404 | 편지를 찾을 수 없어요. |
-| `L005` | 409 | 아직 Jolly가 편지를 검토하고 있어요. |
-
-### 6.4 공통 (C)
-
-| 코드 | HTTP | message |
-| --- | --- | --- |
-| `C001` | 400 | 잘못된 요청이에요. |
-| `C002` | 404 | 요청하신 경로를 찾을 수 없어요. |
-| `C003` | 405 | 지원하지 않는 요청 방식이에요. |
-| `C004` | 429 | 요청이 너무 많아요. 잠시 후 다시 시도해주세요. |
-| `C005` | 500 | 일시적인 오류가 발생했어요. |
+- 최소 지원 버전 미만이면 앱이 강제 업데이트를 유도한다.
+- **공지사항 · 개인정보처리방침 · 이용약관은 별도 API 없이 웹뷰 링크**로 처리한다. URL 은 버전 조회 응답으로 내려준다.
+- 설정 화면 하단의 `현재 버전 1.0.0 (MVP)` 는 앱 로컬 값이다.
+- 버전 조회는 인증 없이 호출 가능하며, 온보딩 가드(§3.2.3) 대상도 아니다.
 
 ---
 
-## 7. 비기능 요구사항
+## 4. 비기능 요구사항
 
-### 7.1 보안 · 개인정보
+### 4.1 보안 · 개인정보
 
-- 편지 본문은 **개인 일기**에 해당하는 민감 데이터. 응답/요청 본문 로깅 금지
+- 편지 본문은 **개인 일기**에 해당하는 민감 데이터. 요청/응답 본문 로깅 금지
 - 모든 조회는 `userId` 를 서버 인증 컨텍스트에서 가져오며, **경로/파라미터의 userId 를 신뢰하지 않는다**
 - HTTPS 전용, HSTS 적용
 - LLM 전송 시 학습 비활성(zero data retention) 옵션 확인
 - 개인정보처리방침에 **AI 처리 위탁 사실**을 명시해야 한다 (앱 심사 대응)
+- 개인정보처리방침에 **탈퇴 후 30일 보유기간**을 명시해야 한다 (§3.1.3). 앱 탈퇴 화면 문구는 바꾸지 않는다.
+- 약관 동의 이력은 유저 행이 삭제될 때까지 보존한다. 동의 시각·버전이 함께 남아야 사후 입증이 가능하다 (§3.2.1).
 
-### 7.2 성능 · 제한
+### 4.2 성능 · 제한
 
 | 항목 | 기준 |
 | --- | --- |
 | 일반 API 응답 | p95 < 300ms |
-| `POST /letters` | LLM 대기 없이 < 300ms |
-| 검토 완료 소요 | 목표 p95 < 60초 |
-| Rate limit | 유저당 `POST /letters` 분당 5회, 전체 API 분당 120회 초과 시 `C004` |
+| 편지 작성 | LLM 대기 없이 < 300ms |
+| 피드백 완료 소요 | 목표 p95 < 60초 (정상 경로 기준. 이벤트 유실 복구 경로는 §3.5.1 참고) |
+| Rate limit | 유저당 편지 작성 분당 5회, 전체 API 분당 120회 초과 시 `COMMON_004` |
 
-### 7.3 운영
+Rate limit 은 R10(하루 작성 개수 무제한)과 충돌하지 않는다. 분당 빈도만 제한하며 일일 총량은 제한하지 않는다.
+
+### 4.3 운영
 
 - Health check: `GET /actuator/health`
-- 모니터링 지표: 편지 생성 수, 검토 성공률, 검토 지연(생성→완료), `FAILED` 건수, LLM 토큰 사용량/비용
-- 알림: `FAILED` 발생 시, 검토 지연 5분 초과 건 누적 시
-- DB 마이그레이션: Flyway 도입 권장 (`ddl-auto` 는 로컬 `update`, 운영 `validate`)
+- 모니터링 지표: 편지 생성 수, 피드백 성공률, 피드백 지연(생성→완료), 실패 건수, LLM 토큰 사용량/비용, **보완 스케줄러 재큐잉 건수**
+- 알림: 피드백 실패 발생 시, 피드백 지연 5분 초과 건 누적 시, 보완 스케줄러가 재큐잉한 건이 발생 시(이벤트 유실 징후)
+- 우표 이미지: S3 + CloudFront, `Cache-Control: public, max-age=31536000` (파일명 불변 전제)
+- DB 마이그레이션: **Flyway 필수**. 전 환경 `ddl-auto: validate` 로 고정하며, 로컬에서도 `update` 를 쓰지 않는다. ERD §7 의 DDL 이 `V1__init.sql` 의 내용이다.
+- 유예기간 만료 삭제 배치는 매일 1회 실행한다 (§3.1.3).
 
 ---
 
-## 8. 추가로 필요한 의존성 · 환경변수
+## 5. 추가로 필요한 의존성 · 환경변수
 
-### 8.1 `build.gradle` 추가 필요
+### 5.1 `build.gradle` 추가 필요
 
 ```gradle
 implementation 'org.springframework.boot:spring-boot-starter-security'
 implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 runtimeOnly   'io.jsonwebtoken:jjwt-impl:0.12.6'
 runtimeOnly   'io.jsonwebtoken:jjwt-jackson:0.12.6'
-implementation 'com.nimbusds:nimbus-jose-jwt:9.40'          // Apple identity token 검증
-implementation 'org.flywaydb:flyway-core'                    // 선택
-implementation 'org.flywaydb:flyway-mysql'                   // 선택
+implementation 'com.nimbusds:nimbus-jose-jwt:9.40'               // Apple identity token 검증
+implementation 'io.github.java-diff-utils:java-diff-utils:4.12'  // 교정 세그먼트 diff
+implementation 'org.flywaydb:flyway-core'                        // 필수
+implementation 'org.flywaydb:flyway-mysql'                       // 필수
 implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'  // API 문서
 ```
 
 > HTTP 클라이언트는 Spring Boot 3.5 의 `RestClient` 를 사용하면 추가 의존성이 필요 없다.
 
-### 8.2 환경변수
+### 5.2 환경변수
 
 | 키 | 설명 |
 | --- | --- |
@@ -915,33 +586,55 @@ implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'  // API
 | `APPLE_TEAM_ID` / `APPLE_KEY_ID` / `APPLE_PRIVATE_KEY` | revoke 용 client_secret 생성 |
 | `ANTHROPIC_API_KEY` | LLM API 키 |
 | `LLM_MODEL` | 사용 모델 ID |
+| `CDN_BASE_URL` | 우표 이미지 base URL |
+| `TERMS_CURRENT_VERSION` | 현재 약관 버전. `dearjolly.terms.current-version` 에 바인딩되어 동의 이력에 기록된다 |
+| `WITHDRAWAL_RETENTION_DAYS` | 탈퇴 유예기간(일). 기본 30 |
 
 ---
 
-## 9. 확정 필요 항목 (Open Questions)
+## 6. 주요 설계 결정
 
-| # | 항목 | 현재 문서의 기본 가정 | 확인 필요 사유 |
-| --- | --- | --- | --- |
-| OQ-1 | 닉네임 중복 허용 여부 | **중복 허용** | 디자인에 중복 에러 상태가 없음. 중복 금지로 갈 경우 `U006` 코드와 검증 API 추가 필요 |
-| OQ-2 | 홈의 "한 달치 모아보기" 구현 방식 | **무한 스크롤 + 선택적 `yearMonth` 필터** | 기획서는 "한 화면에 한 달치", 디자인 시안은 단순 리스트. 월 단위 페이징이면 API 파라미터가 바뀜 |
-| OQ-3 | 공지사항 제공 방식 | **서버 API + `notices` 테이블** | 외부 페이지 링크로 대체하면 §5.7.1 불필요 |
-| OQ-4 | 하루 작성 개수 제한 | **제한 없음** | 시안이 날짜당 1건이라 "하루 1통" 정책일 수 있음. 제한 시 `L006`(오늘은 이미 편지를 보냈어요) 추가 |
-| OQ-5 | 검토 완료 알림 | **없음 (앱 폴링)** | 푸시가 없으면 사용자가 완료 시점을 모름. MVP 이후 FCM 도입 시 재설계 |
-| OQ-6 | 편지 최소 길이 | **1자** | 너무 짧은 편지는 검토 품질이 낮음. 최소 20자 등 하한 필요 여부 |
-| OQ-7 | 문자 인덱스 기준 | **코드포인트** | 이모지 포함 시 iOS/Android 문자열 인덱싱과 어긋날 수 있어 앱과 합의 필요 |
+구현 시 헷갈리기 쉬운 지점의 결정과 근거다.
+
+| 항목 | 결정 | 근거 |
+| --- | --- | --- |
+| 편지 상태 | `SUBMITTED` / `FEEDBACK_IN_PROGRESS` / `FEEDBACK_COMPLETED` (+내부 `FEEDBACK_FAILED`) | 임시저장이 없으므로 `DRAFT` 불필요. 처리 중 상태로 워커 중복 실행·유실을 판별한다. 실패는 사용자에게 숨긴다 |
+| 편지 날짜 | 클라이언트가 작성 시각 + 타임존 명시, 서버가 유효성 검증 | 기기 로컬 날짜와 화면 표시를 정확히 일치시키고, 해외 체류 시에도 현지 날짜로 기록 |
+| 회원탈퇴 | soft delete 후 30일 유예, 배치가 cascade 삭제 | 오삭제·분쟁 대응 여지를 남기면서 사용자에게는 즉시 삭제로 보인다. 재로그인은 항상 신규 가입이므로 "복구 불가"라는 약속이 깨지지 않는다 |
+| 탈퇴 계정 접근 | 인증 필터에서 `status` 확인 후 `AUTH_007` | 탈퇴 직후 최대 30분간 살아 있는 Access Token 을 차단해야 한다 |
+| 약관 동의 | 별도 테이블에 이력 누적, 버전 기록, 재동의 없음 | 개인정보보호법상 동의 이력 입증이 필요하다. 재동의 유도는 UX 설계가 따로 필요하므로 MVP 밖 |
+| 온보딩 가드 | 공통 인터셉터에서 `USER_005` | 목록·홈 응답의 `nickname` non-null 을 보장해 응답 계약이 단순해진다 |
+| 피드백 처리 | 비동기 (`AFTER_COMMIT` 이벤트 + 보완 스케줄러) | LLM 응답을 기다리면 작성 화면이 수십 초 멈춘다 |
+| 재시도 주체 | 워커 인메모리 재예약, 스케줄러는 안전망(1시간) | 백오프를 정확히 지키면서, 스케줄러가 백오프 대기 편지를 가로채는 문제를 임계값 분리로 해결 |
+| 중복 전달 방지 | 동일 유저·동일 본문·60초 차단 | 앱 수정과 키 저장소 없이 재시도 중복을 막는다 |
+| 교정 표현 | 순서 기반 세그먼트 (`UNCHANGED` / `MODIFIED`) | 앱이 인덱스 계산 없이 순차 렌더링. 서버 diff 로 불변식 보장 |
+| 피드백 팁 | 문자열 배열 (0~3개) | `팁없음 / 팁단일 / 팁여러개` 디자인 3상태를 그대로 표현 |
+| 우표 표현 | 응답은 이미지 URL, DB 는 `stamps` 마스터 테이블 | 우표 추가·교체를 행 삽입으로 처리. 앱 배포도 서버 배포도 불필요 |
+| 우표 선택 | LLM 이 활성 우표 이름 목록에서 선택 | 편지 내용과 어울리는 우표가 도착해 기록의 맥락이 살아난다. 랜덤보다 사용자 경험이 낫다 |
+| 홈 조회 | 목록 조회가 헤더 정보까지 반환 | 홈 진입 시 1회 호출로 완료. 홈 정보 조회는 헤더 전용으로 유지 |
+| 목록 정렬 | 서버 정렬 (최신순 / 오래된순) | 페이징된 일부만 클라이언트에서 뒤집으면 전체 정렬이 깨짐 |
+| 하루 작성 수 | 제한 없음 | 쓰고 싶을 때 막지 않는다는 기획 방향 |
+| 닉네임 중복 | 허용 | 표시용 이름이며 디자인에 중복 에러 상태가 없음 |
+| 닉네임 검증 순서 | 길이 → 문자 | 앱이 사유별 문구를 보여주므로 코드가 사유를 구분해야 한다 |
+| email · nickname | NULL 허용 | provider 가 이메일을 주지 않을 수 있고, 닉네임은 온보딩에서 채운다. 가짜 값을 만들지 않는다 |
+| 미리보기 길이 | 원문 앞 50자 | 목록 한 줄 말줄임 기준을 넘기는 길이. 화면 폭이 달라져도 앞에서 잘리지 않음 |
+| 토큰 관리 | 재발급 + 로그아웃 제공, Refresh Token 회전 | Access Token 30분 만료로 인한 재로그인 방지, 탈취 토큰 재사용 차단 |
+| 스키마 관리 | Flyway 필수, 전 환경 `validate` | ERD 가 스키마의 정본이라는 전제가 성립하려면 자동 생성을 허용할 수 없다 |
 
 ---
 
-## 10. MVP 이후 확장 고려
+## 7. MVP 이후 확장 고려
 
 현재 스키마에서 다음 확장이 자연스럽게 가능하도록 설계했다.
 
 | 확장 기능 | 활용 지점 |
 | --- | --- |
-| 표현/단어 정리 | `correction_segments.correction_type` + `original_text` 집계 → 자주 틀리는 표현 목록 |
-| 유료 상세 첨삭 | `feedbacks` 에 `feedback_level` 컬럼 추가, 동일 파이프라인 재사용 |
-| 우표 수집 리워드 | `Stamps` 종류 확대 + `letters.stamp` 집계 |
-| 위젯 | `GET /letters/summary` 재사용 |
-| 일기 프롬프트(질문) | `letters` 에 `prompt_id` 컬럼 추가 |
-| 검토 후 재전송 플로우 | `letters.status` 에 `REVISED` 등 상태 추가, `feedbacks` 는 1:N 으로 확장 |
-| 푸시 알림 | 검토 완료 시점(§5.5.5)에 이벤트 발행 지점 이미 존재 |
+| 약관 개정 · 재동의 유도 | `TERMS_AGREEMENTS.terms_version` 이 이미 기록돼 있어, 현재 버전과 비교하는 판별 로직만 추가하면 된다 |
+| 표현/단어 정리 | 교정 세그먼트에 문법 카테고리 컬럼 추가 → `MODIFIED` 세그먼트 집계로 자주 틀리는 표현 목록 |
+| 유료 상세 첨삭 | 피드백에 등급 컬럼 추가, 동일 파이프라인 재사용 |
+| 우표 수집 리워드 | `STAMPS` 행 추가 + 보유 우표 집계 |
+| 위젯 | 홈 정보 조회 재사용 |
+| 일기 프롬프트(질문) | 편지에 프롬프트 ID 컬럼 추가 |
+| 검토 후 재전송 플로우 | 상태에 `REVISED` 추가, 피드백을 1:N 으로 확장 |
+| 푸시 알림 | 피드백 완료 시점(§3.5.5)에 이벤트 발행 지점 이미 존재 |
+| 관리자 재처리 API | `Role.ROLE_ADMIN` 과 `AUTH_006`(403) 이 이미 정의돼 있다 |

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+COMPOSE="docker compose"
+
+usage() {
+  cat <<'USAGE'
+사용법: ./run.sh [명령]
+
+  (없음) | up   앱 + MySQL + MinIO 기동 (변경 시 이미지 재빌드)
+  down          컨테이너 종료 (데이터 볼륨은 유지)
+  clean         컨테이너 + 볼륨까지 전부 삭제 (DB·이미지 데이터 초기화)
+  restart       앱 컨테이너만 재빌드 후 재기동
+  logs          앱 로그 실시간 확인
+  ps            컨테이너 상태 확인
+USAGE
+}
+
+require_env() {
+  if [ ! -f .env ]; then
+    echo "[run] .env 파일이 없습니다. .env.example 을 복사합니다."
+    cp .env.example .env
+  fi
+}
+
+case "${1:-up}" in
+  up)
+    require_env
+    echo "[run] 컨테이너 기동 (앱 / MySQL / MinIO)"
+    $COMPOSE up -d --build
+    $COMPOSE ps
+    echo "[run] 앱      : http://localhost:$(grep -E '^APP_PORT=' .env | cut -d= -f2)"
+    echo "[run] MinIO   : http://localhost:$(grep -E '^MINIO_CONSOLE_PORT=' .env | cut -d= -f2) (콘솔)"
+    echo "[run] 로그 확인: ./run.sh logs"
+    ;;
+  down)
+    $COMPOSE down
+    ;;
+  clean)
+    echo "[run] 볼륨까지 삭제합니다 (DB·MinIO 데이터 초기화)"
+    $COMPOSE down -v
+    ;;
+  restart)
+    require_env
+    $COMPOSE up -d --build app
+    ;;
+  logs)
+    $COMPOSE logs -f app
+    ;;
+  ps)
+    $COMPOSE ps
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    echo "[run] 알 수 없는 명령: $1" >&2
+    usage
+    exit 1
+    ;;
+esac

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,17 +1,33 @@
+server:
+  port: ${SERVER_PORT:8080}
+
 spring:
   application:
     name: server
 
   datasource:
-    url: ${MYSQL_HOST}
-    username: ${MYSQL_USER}
+    url: ${MYSQL_URL:jdbc:mysql://localhost:3306/dearjolly?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    username: ${MYSQL_USER:jolly}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:
-      ddl-auto: create
-    show-sql: true
+      ddl-auto: ${JPA_DDL_AUTO:create}
+    show-sql: ${JPA_SHOW_SQL:true}
     properties:
       hibernate:
         format_sql: true
+
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
+# ===== MinIO (우표 이미지 저장소) =====
+minio:
+  endpoint: ${MINIO_ENDPOINT:http://localhost:9000}       # 서버 → MinIO 내부 호출용
+  public-endpoint: ${MINIO_PUBLIC_ENDPOINT:http://localhost:9000}  # 클라이언트에 내려줄 이미지 URL 기준
+  access-key: ${MINIO_ACCESS_KEY}
+  secret-key: ${MINIO_SECRET_KEY}
+  bucket: ${MINIO_BUCKET:dear-jolly-stamps}


### PR DESCRIPTION
## 📣 Related Issue
<!-- [closed #이슈번호] 로 merge되면 issue가 자동으로 close되게 명시 -->
- close #

## 📝 Key Changes
<!-- 간단한 변경사항 기재 -->
- Docker Compose 기반 로컬 실행 환경 구성 (`compose.yaml`, `Dockerfile`, `.env.example`, `run.sh`)
- `docs/API명세.md` · `docs/ERD.md` 신규 작성, `docs/기능명세.md` 와 함께 세 문서 정합성 확보 및 최종본 재작성
- 백엔드 코드 컨벤션을 `.claude/skills/` 스킬 8종으로 정의하고 `CLAUDE.md` 에서 라우팅
- `application.yaml` 로컬 실행 기준 정리, `.gitignore` 에 로컬 실행 스크립트 제외 추가

## To Reviewers
<!-- 리뷰어가 어떤 부분을 중점적으로 봐주면 좋을지, 또는 추후 협업에 영향을 끼칠 부분 작성 -->
- 이후 모든 PR 이 이 PR 의 명세 문서(`docs/API명세.md`, `docs/ERD.md`)를 기준으로 쌓입니다. **명세 내용이 실제 기획과 맞는지 먼저 봐주세요.**
- `.claude/skills/` 는 앞으로 코드 리뷰 기준이 되는 컨벤션 문서입니다. 팀 합의와 어긋나는 규칙이 있으면 이 PR 에서 잡는 게 가장 저렴합니다.
- 아직 코드 변경은 없고 실행 환경 + 문서 정비만 있는 단계입니다.
