### PR TITLE
[RELEASE] dev → main

### DIFF
--- a/docs/API명세.md
+++ b/docs/API명세.md
@@ -32,7 +32,7 @@
 - **인증** ✔ — `Authorization` 헤더가 필요하다.
 - **온보딩** ✔ — 온보딩(필수 약관 동의 + 닉네임 등록) 전에 호출하면 `USER_005` 다.
 - **구현** — ✅ 호출 가능, ❌ 명세만 확정되고 아직 개발 전이다.
-- `{provider}` 는 **대문자**(`KAKAO` · `APPLE`)다. 소문자로 호출하면 `COMMON_001` 이다.
+- `{provider}` 는 `KAKAO` · `APPLE` 이며 **대소문자를 가리지 않는다**. (`kakao`, `Kakao` 모두 같다)
 
 ---
 
@@ -46,7 +46,7 @@
 - 앱이 할 일은 세 가지다. **① 이 주소를 연다 → ② 열린 페이지에서 유저가 로그인한다 → ③ 딥링크로 토큰을 받는다.** 코드 교환·회원 생성·토큰 발급은 서버가 처리한다.
 - **앱 SDK 로 받은 소셜 토큰을 서버에 전달하는 방식은 지원하지 않는다.**
 - 유저는 `(provider + provider 회원 식별자)` 로 구분한다. 이메일이 같아도 카카오와 애플은 별개 계정이다.
-- `provider` 가 `KAKAO` · `APPLE` 이 아니면(소문자 포함) `COMMON_001` 이다.
+- `provider` 는 대소문자를 가리지 않는다. `KAKAO` · `APPLE` 중 어느 것도 아니면 `COMMON_001` 이다.
 
 ### [스펙]
 
@@ -58,7 +58,7 @@ GET /api/v1/auth/{provider}
 
 **Path Variable**
 
-- [필수] `provider` (String): 로그인 수단 (`KAKAO`, `APPLE`). 대문자만 허용한다
+- [필수] `provider` (String): 로그인 수단 (`KAKAO`, `APPLE`). 대소문자를 가리지 않는다
 
 **Authorization 헤더**: 불필요
 

--- a/docs/API명세.md
+++ b/docs/API명세.md
@@ -7,6 +7,7 @@
 | 인증 | `Authorization: Bearer {accessToken}` |
 | Content-Type | `application/json; charset=UTF-8` |
 | 날짜 포맷 | 날짜 → `yyyy-MM-dd` / 날짜+시각 → `yyyy-MM-dd'T'HH:mm:ss` |
+| Swagger UI | `/swagger-ui/index.html` — 이 문서와 같은 내용을 담고 직접 호출까지 된다. 우측 상단에서 전체 · 인증 · 사용자 · 편지·홈 · 버전 그룹을 고른다 |
 
 ---
 

--- a/src/main/java/com/dearjolly/server/domain/feedback/dto/response/CorrectionSegmentResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/feedback/dto/response/CorrectionSegmentResponse.java
@@ -19,10 +19,7 @@ public record CorrectionSegmentResponse(
                 requiredMode = Schema.RequiredMode.REQUIRED)
         String correctedText,
 
-        @Schema(
-                description = "수정 여부. UNCHANGED 는 검은 글씨 그대로, "
-                        + "MODIFIED 는 originalText 를 빨간 취소선으로 찍고 바로 뒤에 correctedText 를 초록 하이라이트로 찍는다",
-                requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "수정 여부", requiredMode = Schema.RequiredMode.REQUIRED)
         CorrectionType type
 ) {
     public static CorrectionSegmentResponse from(CorrectionSegments segment) {

--- a/src/main/java/com/dearjolly/server/domain/feedback/dto/response/CorrectionSegmentResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/feedback/dto/response/CorrectionSegmentResponse.java
@@ -2,11 +2,27 @@ package com.dearjolly.server.domain.feedback.dto.response;
 
 import com.dearjolly.server.domain.feedback.entity.CorrectionSegments;
 import com.dearjolly.server.domain.feedback.enums.CorrectionType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "교정문을 그리는 조각 하나. 공백도 조각에 포함되므로 앱이 공백을 임의로 추가하지 않는다")
 public record CorrectionSegmentResponse(
+
+        @Schema(description = "순서 (1부터 시작)", example = "2", requiredMode = Schema.RequiredMode.REQUIRED)
         int sequence,
+
+        @Schema(description = "원본 텍스트 조각", example = "got", requiredMode = Schema.RequiredMode.REQUIRED)
         String originalText,
+
+        @Schema(
+                description = "교정된 텍스트 조각. MODIFIED 이면서 빈 문자열이면 삭제 제안이다",
+                example = "received",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         String correctedText,
+
+        @Schema(
+                description = "수정 여부. UNCHANGED 는 검은 글씨 그대로, "
+                        + "MODIFIED 는 originalText 를 빨간 취소선으로 찍고 바로 뒤에 correctedText 를 초록 하이라이트로 찍는다",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         CorrectionType type
 ) {
     public static CorrectionSegmentResponse from(CorrectionSegments segment) {

--- a/src/main/java/com/dearjolly/server/domain/feedback/dto/response/FeedbackGetResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/feedback/dto/response/FeedbackGetResponse.java
@@ -11,19 +11,16 @@ public record FeedbackGetResponse(
         @Schema(description = "피드백 ID", example = "101", requiredMode = Schema.RequiredMode.REQUIRED)
         Long feedbackId,
 
-        @Schema(
-                description = "교정된 전체 내용. correctionSegments 의 correctedText 를 모두 이은 것과 정확히 일치한다",
-                example = "I received flowers from a friend today.",
+        @Schema(description = "교정된 전체 내용", example = "I received flowers from a friend today.",
                 requiredMode = Schema.RequiredMode.REQUIRED)
         String correctedContent,
 
         @Schema(
                 description = "피드백 팁 목록 (0~3개). 비어 있으면 앱은 팁 영역을 표시하지 않는다",
-                example = "[\"이 문맥에서는 'got'보다 'received'가 더 자연스러워요.\"]",
                 requiredMode = Schema.RequiredMode.REQUIRED)
         List<String> tips,
 
-        @Schema(description = "교정 조각 목록 (1개 이상). sequence 순서대로 이어붙여 그린다",
+        @Schema(description = "교정 조각 목록. sequence 순서대로 이어붙여 그린다",
                 requiredMode = Schema.RequiredMode.REQUIRED)
         List<CorrectionSegmentResponse> correctionSegments
 ) {

--- a/src/main/java/com/dearjolly/server/domain/feedback/dto/response/FeedbackGetResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/feedback/dto/response/FeedbackGetResponse.java
@@ -2,12 +2,29 @@ package com.dearjolly.server.domain.feedback.dto.response;
 
 import com.dearjolly.server.domain.feedback.entity.FeedbackTips;
 import com.dearjolly.server.domain.feedback.entity.Feedbacks;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+@Schema(description = "편지에 도착한 AI 피드백")
 public record FeedbackGetResponse(
+
+        @Schema(description = "피드백 ID", example = "101", requiredMode = Schema.RequiredMode.REQUIRED)
         Long feedbackId,
+
+        @Schema(
+                description = "교정된 전체 내용. correctionSegments 의 correctedText 를 모두 이은 것과 정확히 일치한다",
+                example = "I received flowers from a friend today.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         String correctedContent,
+
+        @Schema(
+                description = "피드백 팁 목록 (0~3개). 비어 있으면 앱은 팁 영역을 표시하지 않는다",
+                example = "[\"이 문맥에서는 'got'보다 'received'가 더 자연스러워요.\"]",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         List<String> tips,
+
+        @Schema(description = "교정 조각 목록 (1개 이상). sequence 순서대로 이어붙여 그린다",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         List<CorrectionSegmentResponse> correctionSegments
 ) {
     public static FeedbackGetResponse from(Feedbacks feedback) {

--- a/src/main/java/com/dearjolly/server/domain/feedback/enums/CorrectionType.java
+++ b/src/main/java/com/dearjolly/server/domain/feedback/enums/CorrectionType.java
@@ -1,8 +1,10 @@
 package com.dearjolly.server.domain.feedback.enums;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Schema(description = "교정 조각의 수정 여부")
 @Getter
 @RequiredArgsConstructor
 public enum CorrectionType {

--- a/src/main/java/com/dearjolly/server/domain/letter/controller/HomeController.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/controller/HomeController.java
@@ -5,7 +5,12 @@ import static org.springframework.http.HttpStatus.OK;
 import com.dearjolly.server.domain.letter.dto.response.HomeGetResponse;
 import com.dearjolly.server.domain.letter.service.LetterService;
 import com.dearjolly.server.global.auth.principal.LoginUser;
+import com.dearjolly.server.global.exception.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,14 +18,37 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "홈", description = "홈 헤더 정보 조회 API")
+@Tag(name = "홈", description = """
+        홈 헤더 정보 조회 API.
+
+        **온보딩 가드 대상이다.** 필수 약관 2종 동의와 닉네임 등록을 마치지 않은 유저가 호출하면 `USER_005`(400) 다.""")
 @RestController
 @RequestMapping("/api/v1/home")
 @RequiredArgsConstructor
 public class HomeController {
     private final LetterService letterService;
 
-    @Operation(summary = "닉네임, 모은 우표 수 조회")
+    @Operation(
+            summary = "닉네임, 모은 우표 수 조회",
+            description = """
+                    홈 헤더의 닉네임 · 모은 우표 수를 조회한다.
+
+                    - **홈 진입 시 `GET /api/v1/letters` 와 함께 호출한다.** 편지 목록 응답에는 이 두 값이 들어 있지 않다.
+                    - 헤더만 갱신할 때는 이 API 만 다시 호출하면 된다.
+                    - `totalStampCount` 는 **작성한 편지 수가 아니라 피드백이 완료된 편지 수**다.
+                      편지 3건을 썼고 1건이 피드백 대기라면 `2` 다.
+                    - `nickname` 은 온보딩 가드 덕분에 **항상 값이 있다.**""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "`USER_005` 온보딩 미완료",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "`AUTH_005` 유효하지 않은 토큰 / `AUTH_007` 탈퇴한 계정",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping
     public ResponseEntity<HomeGetResponse> getHome(@LoginUser Long userId) {
         return ResponseEntity

--- a/src/main/java/com/dearjolly/server/domain/letter/controller/HomeController.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/controller/HomeController.java
@@ -18,10 +18,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "홈", description = """
-        홈 헤더 정보 조회 API.
-
-        **온보딩 가드 대상이다.** 필수 약관 2종 동의와 닉네임 등록을 마치지 않은 유저가 호출하면 `USER_005`(400) 다.""")
+@Tag(name = "홈", description = "홈 헤더 정보 조회 API. **온보딩 가드 대상**이라 미완료 유저가 호출하면 `USER_005`(400) 다.")
 @RestController
 @RequestMapping("/api/v1/home")
 @RequiredArgsConstructor
@@ -31,13 +28,9 @@ public class HomeController {
     @Operation(
             summary = "닉네임, 모은 우표 수 조회",
             description = """
-                    홈 헤더의 닉네임 · 모은 우표 수를 조회한다.
-
                     - **홈 진입 시 `GET /api/v1/letters` 와 함께 호출한다.** 편지 목록 응답에는 이 두 값이 들어 있지 않다.
-                    - 헤더만 갱신할 때는 이 API 만 다시 호출하면 된다.
-                    - `totalStampCount` 는 **작성한 편지 수가 아니라 피드백이 완료된 편지 수**다.
-                      편지 3건을 썼고 1건이 피드백 대기라면 `2` 다.
-                    - `nickname` 은 온보딩 가드 덕분에 **항상 값이 있다.**""")
+                    - `totalStampCount` 는 작성한 편지 수가 아니라 **피드백이 완료된 편지 수**다.
+                    - `nickname` 은 온보딩 가드 덕분에 항상 값이 있다.""")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(

--- a/src/main/java/com/dearjolly/server/domain/letter/controller/LetterController.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/controller/LetterController.java
@@ -34,13 +34,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "편지", description = """
-        편지 작성, 조회 API.
+        편지 작성, 조회 API. **온보딩 가드 대상**이라 미완료 유저가 호출하면 `USER_005`(400) 다.
 
-        **온보딩 가드 대상이다.** 필수 약관 2종 동의와 닉네임 등록을 마치지 않은 유저가 호출하면 `USER_005`(400) 다.
-
-        편지는 **전달 후 수정 · 삭제할 수 없다.** 수정 · 삭제 API 가 없다.
-        작성하면 AI 피드백이 비동기로 시작되며, 상태는 `SUBMITTED` → `FEEDBACK_IN_PROGRESS` → `FEEDBACK_COMPLETED` 로 진행된다.
-        앱은 앞의 두 상태를 동일하게 렌더링한다.""")
+        편지는 전달 후 수정 · 삭제할 수 없다. 상태는 `SUBMITTED` → `FEEDBACK_IN_PROGRESS` → `FEEDBACK_COMPLETED` 로 진행되며 앱은 앞의 둘을 동일하게 렌더링한다.""")
 @RestController
 @RequestMapping("/api/v1/letters")
 @RequiredArgsConstructor
@@ -50,28 +46,14 @@ public class LetterController {
     @Operation(
             summary = "편지 작성 및 피드백 요청 (60초 이내 같은 본문 재전송은 200 으로 최초 편지 반환)",
             description = """
-                    편지를 작성한다. 저장되면 AI 피드백이 시작되지만 **응답은 피드백을 기다리지 않고 바로 내려온다.**
+                    저장되면 AI 피드백이 시작되지만 **응답은 피드백을 기다리지 않고 바로 내려온다.**
 
-                    - 본문은 **영어 전용, 1~500자**다. 한글이 섞이면 거부하고, 숫자 · 구두점 · 이모지는 허용한다.
-                    - 편지 날짜는 앱이 보낸 `writtenAt` 의 날짜 부분이다. **KST 를 강제하지 않아** 해외에서 쓴 편지는 현지 날짜로 기록된다.
-                    - **하루 작성 개수 제한이 없다.** 같은 날짜 카드가 목록에 여러 개 쌓일 수 있다.
-                    - 작성 직후 상태는 항상 `SUBMITTED` 이고 **우표는 `soon`(준비 중) 우표**다. 피드백이 끝나야 편지에 맞는 우표로 바뀐다.
-
-                    **검증 규칙** — `content` → `timeZone` → `writtenAt` 순서로 보며, 먼저 걸린 사유 하나만 내려간다.
-
-                    | 순서 | 규칙 | 상세 | code |
-                    | --- | --- | --- | --- |
-                    | 1 | 필수 | `content` 가 비었거나 공백만 있는 값 불가 | `LETTER_001` |
-                    | 1 | 길이 | **500자 초과** 불가 (문자 수, 공백 포함) | `LETTER_003` |
-                    | 1 | 언어 | 한글 포함 시 거부 | `LETTER_004` |
-                    | 2 | 타임존 | 유효한 타임존 ID. 누락 불가 | `LETTER_005` |
-                    | 3 | 작성 시각 | 서버 현재 시각 기준 **±24시간 이내**. 누락 불가 | `LETTER_005` |
-
-                    `writtenAt` 이 `2025-13-45T99:99:99` 처럼 **날짜로 해석조차 되지 않는 문자열**이면 `LETTER_005` 가 아니라 `COMMON_001` 이다.
-
-                    **중복 전달은 서버가 막는다.** 60초 안에 같은 내용을 다시 보내면 새 편지를 만들지 않고 최초 편지를 `200 OK` 로 돌려준다.
-                    앱이 별도 헤더를 보낼 필요가 없다. 중복 판정은 그 유저의 **직전 편지 1건**만 보므로, 60초 안이라도 사이에 다른 내용의 편지를
-                    한 통 쓰면 중복으로 잡히지 않는다. 앱은 `201` 과 `200` 을 구분할 필요 없이 동일하게 완료 화면으로 이동한다.""")
+                    - 본문은 **영어 전용, 1~500자**다. 숫자 · 구두점 · 이모지는 허용한다.
+                    - 편지 날짜는 `writtenAt` 의 날짜 부분이다. KST 를 강제하지 않아 해외에서 쓴 편지는 현지 날짜로 기록된다.
+                    - 하루 작성 개수 제한이 없다. 작성 직후 우표는 항상 `soon`(준비 중) 우표다.
+                    - 검증은 `content` → `timeZone` → `writtenAt` 순서로 보며 먼저 걸린 사유 하나만 내려간다.
+                    - **60초 안에 같은 내용을 다시 보내면** 새 편지를 만들지 않고 최초 편지를 `200` 으로 돌려준다.
+                      앱은 `201` 과 `200` 을 구분할 필요 없다.""")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "작성 성공"),
             @ApiResponse(
@@ -132,23 +114,12 @@ public class LetterController {
             description = """
                     편지 상세와 도착한 피드백(교정문 · 팁)을 조회한다.
 
-                    - **피드백이 완료된 편지를 조회하면 읽음 처리된다.** 별도의 읽음 처리 API 는 없고, 한 번 읽으면 다시 미열람으로 돌아가지 않는다.
-                    - 피드백 완료 전 편지는 조회해도 읽음 처리되지 않는다. **피드백이 도착한 뒤 목록의 빨간 점은 그대로 뜬다.**
+                    - **피드백이 완료된 편지를 조회하면 읽음 처리된다.** 별도의 읽음 처리 API 는 없다.
                     - **본인 편지만** 조회할 수 있다. 없는 편지든 남의 편지든 똑같이 `LETTER_002`(404) 다.
-                    - 피드백 완료 전에도 응답은 성공한다. 이때 `feedback` 은 `null` 이고 `stampImage` 는 `soon`(준비 중) 우표 URL 이다.
-                      앱은 완료 전 카드의 진입 자체를 막는다.
-                    - 팁은 편지마다 0~3개이며, `tips` 가 `[]` 면 팁 영역을 표시하지 않는다.
-                    - 우표는 AI 가 편지 내용에 맞춰 고르고 종류가 운영 중 늘거나 바뀔 수 있다.
-                      앱은 **`stampImage` URL 을 그대로 표시하고 우표 종류로 분기하지 않는다.**
-
-                    **교정문 그리는 법** — `correctionSegments` 를 `sequence` 순서대로 이어붙인다.
-                    `originalText` 를 모두 이으면 원문 전체와, `correctedText` 를 모두 이으면 `correctedContent` 전체와 정확히 일치하므로
-                    앱은 인덱스 계산 없이 순서대로 그리기만 하면 된다.
-
-                    - `type == "UNCHANGED"` → 검은 글씨 그대로
-                    - `type == "MODIFIED"` → `originalText` 를 빨간 취소선으로 찍고 바로 뒤에 `correctedText` 를 초록 하이라이트로 찍는다
-                    - 삭제 제안은 `type == "MODIFIED"` 이면서 `correctedText` 가 빈 문자열인 조각이다
-                    - 공백도 조각에 포함돼 내려가므로 **앱이 공백을 임의로 추가하지 않는다.**""")
+                    - 피드백 완료 전에도 응답은 성공하며 이때 `feedback` 은 `null` 이다. 앱은 완료 전 카드의 진입을 막는다.
+                    - 우표는 종류가 운영 중 바뀔 수 있다. 앱은 `stampImage` URL 을 그대로 표시하고 우표 종류로 분기하지 않는다.
+                    - 교정문은 `correctionSegments` 를 `sequence` 순서대로 이어붙여 그린다.
+                      `UNCHANGED` 는 그대로, `MODIFIED` 는 `originalText` 를 취소선으로 찍고 뒤에 `correctedText` 를 붙인다.""")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공. 피드백 완료 전이면 feedback 이 null 이다"),
             @ApiResponse(
@@ -178,23 +149,13 @@ public class LetterController {
     @Operation(
             summary = "전체 편지 목록 조회",
             description = """
-                    홈 화면의 편지 목록을 조회한다. 닉네임 · 우표 수는 내려가지 않으므로,
-                    **홈 진입 시 `GET /api/v1/home` 과 함께 호출한다.**
+                    홈 화면의 편지 목록을 조회한다. 닉네임 · 우표 수는 내려가지 않으므로 **홈 진입 시 `GET /api/v1/home` 과 함께 호출한다.**
 
                     - **본인 편지만** 조회된다. 유저 정보는 토큰에서 가져오므로 파라미터로 보내지 않는다.
-                    - 편지를 쓰지 않은 날은 응답에 나타나지 않는다. **캘린더가 아니라 기록이 쌓이는 목록**이다.
-                    - 정렬은 서버가 처리하므로 앱은 받은 순서대로 그린다. `page` · `size` · `sort` 가 허용 범위를 벗어나면 `COMMON_001` 이다.
-                    - 정렬 기준은 **편지 날짜**이며, 같은 날짜에 여러 통을 썼다면 `LATEST` 는 **나중에 쓴 편지가 먼저**,
-                      `OLDEST` 는 **먼저 쓴 편지가 먼저** 온다.
-                    - 편지가 한 통도 없으면 `letters` 는 빈 배열이고 `hasNext` 는 `false` 다.
-
-                    **앱의 카드 렌더링**
-                    - `SUBMITTED` · `FEEDBACK_IN_PROGRESS` — 회색 `soon` 우표 · `ic_more_sm` 미노출 · 터치 불가.
-                      우표는 상태와 무관하게 `stampImage` 를 그대로 표시한다.
-                    - `FEEDBACK_COMPLETED` — `stampImage` 표시 · `ic_more_sm` 노출 · 카드 전체 영역 터치 시 상세 이동.
-                    - `FEEDBACK_COMPLETED` 이면서 `isRead == false` 면 **날짜 앞에 빨간 점**을 찍는다.
-                      완료 전 편지도 `isRead` 는 `false` 지만 빨간 점을 표시하지 않는다.
-                    - 목록에 `FEEDBACK_COMPLETED` 가 아닌 항목이 있으면, 앱은 화면 재진입 · 새로고침 때 다시 조회해 상태 변화를 확인한다.""")
+                    - 편지를 쓰지 않은 날은 응답에 나타나지 않는다. 캘린더가 아니라 기록이 쌓이는 목록이다.
+                    - 정렬은 서버가 처리하므로 앱은 받은 순서대로 그린다. 정렬 기준은 편지 날짜다.
+                    - `FEEDBACK_COMPLETED` 이면서 `isRead == false` 면 날짜 앞에 빨간 점을 찍는다. 완료 전 편지에는 찍지 않는다.
+                    - 목록에 완료되지 않은 항목이 있으면 앱은 화면 재진입 · 새로고침 때 다시 조회한다.""")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공. 편지가 없으면 빈 배열이다"),
             @ApiResponse(

--- a/src/main/java/com/dearjolly/server/domain/letter/controller/LetterController.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/controller/LetterController.java
@@ -11,8 +11,14 @@ import com.dearjolly.server.domain.letter.dto.response.LetterListResponse;
 import com.dearjolly.server.domain.letter.enums.LetterSort;
 import com.dearjolly.server.domain.letter.service.LetterService;
 import com.dearjolly.server.global.auth.principal.LoginUser;
+import com.dearjolly.server.global.exception.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -27,14 +33,88 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "편지", description = "편지 작성, 조회 API")
+@Tag(name = "편지", description = """
+        편지 작성, 조회 API.
+
+        **온보딩 가드 대상이다.** 필수 약관 2종 동의와 닉네임 등록을 마치지 않은 유저가 호출하면 `USER_005`(400) 다.
+
+        편지는 **전달 후 수정 · 삭제할 수 없다.** 수정 · 삭제 API 가 없다.
+        작성하면 AI 피드백이 비동기로 시작되며, 상태는 `SUBMITTED` → `FEEDBACK_IN_PROGRESS` → `FEEDBACK_COMPLETED` 로 진행된다.
+        앱은 앞의 두 상태를 동일하게 렌더링한다.""")
 @RestController
 @RequestMapping("/api/v1/letters")
 @RequiredArgsConstructor
 public class LetterController {
     private final LetterService letterService;
 
-    @Operation(summary = "편지 작성 및 피드백 요청 (60초 이내 같은 본문 재전송은 200 으로 최초 편지 반환)")
+    @Operation(
+            summary = "편지 작성 및 피드백 요청 (60초 이내 같은 본문 재전송은 200 으로 최초 편지 반환)",
+            description = """
+                    편지를 작성한다. 저장되면 AI 피드백이 시작되지만 **응답은 피드백을 기다리지 않고 바로 내려온다.**
+
+                    - 본문은 **영어 전용, 1~500자**다. 한글이 섞이면 거부하고, 숫자 · 구두점 · 이모지는 허용한다.
+                    - 편지 날짜는 앱이 보낸 `writtenAt` 의 날짜 부분이다. **KST 를 강제하지 않아** 해외에서 쓴 편지는 현지 날짜로 기록된다.
+                    - **하루 작성 개수 제한이 없다.** 같은 날짜 카드가 목록에 여러 개 쌓일 수 있다.
+                    - 작성 직후 상태는 항상 `SUBMITTED` 이고 **우표는 `soon`(준비 중) 우표**다. 피드백이 끝나야 편지에 맞는 우표로 바뀐다.
+
+                    **검증 규칙** — `content` → `timeZone` → `writtenAt` 순서로 보며, 먼저 걸린 사유 하나만 내려간다.
+
+                    | 순서 | 규칙 | 상세 | code |
+                    | --- | --- | --- | --- |
+                    | 1 | 필수 | `content` 가 비었거나 공백만 있는 값 불가 | `LETTER_001` |
+                    | 1 | 길이 | **500자 초과** 불가 (문자 수, 공백 포함) | `LETTER_003` |
+                    | 1 | 언어 | 한글 포함 시 거부 | `LETTER_004` |
+                    | 2 | 타임존 | 유효한 타임존 ID. 누락 불가 | `LETTER_005` |
+                    | 3 | 작성 시각 | 서버 현재 시각 기준 **±24시간 이내**. 누락 불가 | `LETTER_005` |
+
+                    `writtenAt` 이 `2025-13-45T99:99:99` 처럼 **날짜로 해석조차 되지 않는 문자열**이면 `LETTER_005` 가 아니라 `COMMON_001` 이다.
+
+                    **중복 전달은 서버가 막는다.** 60초 안에 같은 내용을 다시 보내면 새 편지를 만들지 않고 최초 편지를 `200 OK` 로 돌려준다.
+                    앱이 별도 헤더를 보낼 필요가 없다. 중복 판정은 그 유저의 **직전 편지 1건**만 보므로, 60초 안이라도 사이에 다른 내용의 편지를
+                    한 통 쓰면 중복으로 잡히지 않는다. 앱은 `201` 과 `200` 을 구분할 필요 없이 동일하게 완료 화면으로 이동한다.""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "작성 성공"),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "중복 전달. 60초 안에 같은 내용을 다시 보낸 경우이며, 본문은 최초 편지의 201 응답과 완전히 같다",
+                    content = @Content(schema = @Schema(implementation = LetterCreateResponse.class))),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "`LETTER_001` · `LETTER_003` · `LETTER_004` · `LETTER_005` 검증 실패 / "
+                            + "`COMMON_001` 날짜 파싱 실패 · 바디 형식 오류 / `USER_005` 온보딩 미완료",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "LETTER_001",
+                                            value = """
+                                                    {"status": 400, "code": "LETTER_001", "message": "편지 내용은 null일 수 없습니다."}"""),
+                                    @ExampleObject(
+                                            name = "LETTER_003",
+                                            value = """
+                                                    {"status": 400, "code": "LETTER_003", "message": "편지 내용은 500자를 초과할 수 없습니다."}"""),
+                                    @ExampleObject(
+                                            name = "LETTER_004",
+                                            value = """
+                                                    {"status": 400, "code": "LETTER_004", "message": "편지는 영어로만 작성할 수 있습니다."}"""),
+                                    @ExampleObject(
+                                            name = "LETTER_005",
+                                            value = """
+                                                    {"status": 400, "code": "LETTER_005", "message": "편지 작성 시각 정보가 올바르지 않습니다."}"""),
+                                    @ExampleObject(
+                                            name = "COMMON_001",
+                                            value = """
+                                                    {"status": 400, "code": "COMMON_001", "message": "잘못된 요청입니다."}"""),
+                                    @ExampleObject(
+                                            name = "USER_005",
+                                            value = """
+                                                    {"status": 400, "code": "USER_005", "message": "온보딩을 먼저 완료해야 합니다."}""")
+                            })),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "`AUTH_005` 유효하지 않은 토큰 / `AUTH_007` 탈퇴한 계정",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @PostMapping
     public ResponseEntity<LetterCreateResponse> createLetter(
             @LoginUser Long userId,
@@ -47,7 +127,43 @@ public class LetterController {
                 .body(result.response());
     }
 
-    @Operation(summary = "편지 상세 · 피드백 조회 (피드백이 완료된 편지는 조회 시 읽음 처리)")
+    @Operation(
+            summary = "편지 상세 · 피드백 조회 (피드백이 완료된 편지는 조회 시 읽음 처리)",
+            description = """
+                    편지 상세와 도착한 피드백(교정문 · 팁)을 조회한다.
+
+                    - **피드백이 완료된 편지를 조회하면 읽음 처리된다.** 별도의 읽음 처리 API 는 없고, 한 번 읽으면 다시 미열람으로 돌아가지 않는다.
+                    - 피드백 완료 전 편지는 조회해도 읽음 처리되지 않는다. **피드백이 도착한 뒤 목록의 빨간 점은 그대로 뜬다.**
+                    - **본인 편지만** 조회할 수 있다. 없는 편지든 남의 편지든 똑같이 `LETTER_002`(404) 다.
+                    - 피드백 완료 전에도 응답은 성공한다. 이때 `feedback` 은 `null` 이고 `stampImage` 는 `soon`(준비 중) 우표 URL 이다.
+                      앱은 완료 전 카드의 진입 자체를 막는다.
+                    - 팁은 편지마다 0~3개이며, `tips` 가 `[]` 면 팁 영역을 표시하지 않는다.
+                    - 우표는 AI 가 편지 내용에 맞춰 고르고 종류가 운영 중 늘거나 바뀔 수 있다.
+                      앱은 **`stampImage` URL 을 그대로 표시하고 우표 종류로 분기하지 않는다.**
+
+                    **교정문 그리는 법** — `correctionSegments` 를 `sequence` 순서대로 이어붙인다.
+                    `originalText` 를 모두 이으면 원문 전체와, `correctedText` 를 모두 이으면 `correctedContent` 전체와 정확히 일치하므로
+                    앱은 인덱스 계산 없이 순서대로 그리기만 하면 된다.
+
+                    - `type == "UNCHANGED"` → 검은 글씨 그대로
+                    - `type == "MODIFIED"` → `originalText` 를 빨간 취소선으로 찍고 바로 뒤에 `correctedText` 를 초록 하이라이트로 찍는다
+                    - 삭제 제안은 `type == "MODIFIED"` 이면서 `correctedText` 가 빈 문자열인 조각이다
+                    - 공백도 조각에 포함돼 내려가므로 **앱이 공백을 임의로 추가하지 않는다.**""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공. 피드백 완료 전이면 feedback 이 null 이다"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "`USER_005` 온보딩 미완료",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "`AUTH_005` 유효하지 않은 토큰 / `AUTH_007` 탈퇴한 계정",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "`LETTER_002` 존재하지 않거나 본인 편지가 아니다",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping("/{letterId}")
     public ResponseEntity<LetterGetResponse> getLetter(
             @LoginUser Long userId,
@@ -59,15 +175,56 @@ public class LetterController {
                 .body(letterService.getLetter(userId, letterId));
     }
 
-    @Operation(summary = "전체 편지 목록 조회")
+    @Operation(
+            summary = "전체 편지 목록 조회",
+            description = """
+                    홈 화면의 편지 목록을 조회한다. 닉네임 · 우표 수는 내려가지 않으므로,
+                    **홈 진입 시 `GET /api/v1/home` 과 함께 호출한다.**
+
+                    - **본인 편지만** 조회된다. 유저 정보는 토큰에서 가져오므로 파라미터로 보내지 않는다.
+                    - 편지를 쓰지 않은 날은 응답에 나타나지 않는다. **캘린더가 아니라 기록이 쌓이는 목록**이다.
+                    - 정렬은 서버가 처리하므로 앱은 받은 순서대로 그린다. `page` · `size` · `sort` 가 허용 범위를 벗어나면 `COMMON_001` 이다.
+                    - 정렬 기준은 **편지 날짜**이며, 같은 날짜에 여러 통을 썼다면 `LATEST` 는 **나중에 쓴 편지가 먼저**,
+                      `OLDEST` 는 **먼저 쓴 편지가 먼저** 온다.
+                    - 편지가 한 통도 없으면 `letters` 는 빈 배열이고 `hasNext` 는 `false` 다.
+
+                    **앱의 카드 렌더링**
+                    - `SUBMITTED` · `FEEDBACK_IN_PROGRESS` — 회색 `soon` 우표 · `ic_more_sm` 미노출 · 터치 불가.
+                      우표는 상태와 무관하게 `stampImage` 를 그대로 표시한다.
+                    - `FEEDBACK_COMPLETED` — `stampImage` 표시 · `ic_more_sm` 노출 · 카드 전체 영역 터치 시 상세 이동.
+                    - `FEEDBACK_COMPLETED` 이면서 `isRead == false` 면 **날짜 앞에 빨간 점**을 찍는다.
+                      완료 전 편지도 `isRead` 는 `false` 지만 빨간 점을 표시하지 않는다.
+                    - 목록에 `FEEDBACK_COMPLETED` 가 아닌 항목이 있으면, 앱은 화면 재진입 · 새로고침 때 다시 조회해 상태 변화를 확인한다.""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공. 편지가 없으면 빈 배열이다"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "`COMMON_001` 페이징 파라미터 제약 위반 / `USER_005` 온보딩 미완료",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "COMMON_001",
+                                            value = """
+                                                    {"status": 400, "code": "COMMON_001", "message": "잘못된 요청입니다."}"""),
+                                    @ExampleObject(
+                                            name = "USER_005",
+                                            value = """
+                                                    {"status": 400, "code": "USER_005", "message": "온보딩을 먼저 완료해야 합니다."}""")
+                            })),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "`AUTH_005` 유효하지 않은 토큰 / `AUTH_007` 탈퇴한 계정",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping
     public ResponseEntity<LetterListResponse> getLetters(
             @LoginUser Long userId,
-            @Parameter(description = "페이지 번호 (0 이상)")
+            @Parameter(description = "페이지 번호 (0 이상)", example = "0")
             @RequestParam(defaultValue = "0") @Min(0) int page,
-            @Parameter(description = "페이지 크기 (1~50)")
+            @Parameter(description = "페이지 크기 (1~50)", example = "10")
             @RequestParam(defaultValue = "10") @Min(1) @Max(50) int size,
-            @Parameter(description = "정렬 기준 (LATEST, OLDEST)")
+            @Parameter(description = "정렬 기준 - LATEST 최신순 / OLDEST 오래된 순")
             @RequestParam(defaultValue = "LATEST") LetterSort sort
     ) {
         return ResponseEntity

--- a/src/main/java/com/dearjolly/server/domain/letter/dto/request/LetterCreateRequest.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/dto/request/LetterCreateRequest.java
@@ -1,10 +1,27 @@
 package com.dearjolly.server.domain.letter.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
+@Schema(description = "편지 작성 요청")
 public record LetterCreateRequest(
+
+        @Schema(
+                description = "편지 내용. 영어 전용, 1~500자 (문자 수, 공백 포함)",
+                example = "I got flowers from a friend today. It really touched me.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         String content,
+
+        @Schema(
+                description = "기기 로컬 기준 작성 시각. 서버 현재 시각 기준 ±24시간 이내",
+                example = "2025-11-01T21:00:00",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDateTime writtenAt,
+
+        @Schema(
+                description = "기기 타임존 ID",
+                example = "Asia/Seoul",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         String timeZone
 ) {
 }

--- a/src/main/java/com/dearjolly/server/domain/letter/dto/response/HomeGetResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/dto/response/HomeGetResponse.java
@@ -1,7 +1,16 @@
 package com.dearjolly.server.domain.letter.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "홈 헤더 응답")
 public record HomeGetResponse(
+
+        @Schema(description = "유저 닉네임. 온보딩 가드 덕분에 항상 값이 있다", example = "Sally",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         String nickname,
+
+        @Schema(description = "모은 우표 총 개수 (피드백이 완료된 편지 수)", example = "3",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         int totalStampCount
 ) {
     public static HomeGetResponse of(String nickname, long totalStampCount) {

--- a/src/main/java/com/dearjolly/server/domain/letter/dto/response/LetterCreateResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/dto/response/LetterCreateResponse.java
@@ -1,12 +1,22 @@
 package com.dearjolly.server.domain.letter.dto.response;
 
 import com.dearjolly.server.domain.letter.entity.Letters;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Schema(description = "편지 작성 응답")
 public record LetterCreateResponse(
+
+        @Schema(description = "편지 ID", example = "16", requiredMode = Schema.RequiredMode.REQUIRED)
         Long letterId,
+
+        @Schema(description = "편지 날짜 (writtenAt 의 날짜 부분)", example = "2025-11-01",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDate date,
+
+        @Schema(description = "저장 시각 (요청의 timeZone 기준, 초 단위까지)", example = "2025-11-01T21:00:03",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDateTime createdAt
 ) {
     public static LetterCreateResponse from(Letters letter) {

--- a/src/main/java/com/dearjolly/server/domain/letter/dto/response/LetterGetResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/dto/response/LetterGetResponse.java
@@ -4,14 +4,35 @@ import com.dearjolly.server.domain.feedback.dto.response.FeedbackGetResponse;
 import com.dearjolly.server.domain.feedback.entity.Feedbacks;
 import com.dearjolly.server.domain.letter.entity.Letters;
 import com.dearjolly.server.domain.letter.enums.Status;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
+@Schema(description = "편지 상세 · 피드백 응답")
 public record LetterGetResponse(
+
+        @Schema(description = "편지 ID", example = "15", requiredMode = Schema.RequiredMode.REQUIRED)
         Long letterId,
+
+        @Schema(description = "편지 날짜", example = "2025-11-01", requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDate date,
+
+        @Schema(description = "원본 편지 내용", example = "I got flowers from a friend today.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         String originalContent,
+
+        @Schema(
+                description = "편지 상태",
+                allowableValues = {"SUBMITTED", "FEEDBACK_IN_PROGRESS", "FEEDBACK_COMPLETED"},
+                requiredMode = Schema.RequiredMode.REQUIRED)
         Status status,
+
+        @Schema(
+                description = "우표 이미지 URL. 항상 값이 있으며, 피드백 완료 전에는 soon(준비 중) 우표다",
+                example = "http://localhost:9000/dear-jolly-stamps/stamp/soon.png",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         String stampImage,
+
+        @Schema(description = "피드백 정보. 피드백 완료 전에는 null 이다")
         FeedbackGetResponse feedback
 ) {
     public static LetterGetResponse of(Letters letter, String stampImage) {

--- a/src/main/java/com/dearjolly/server/domain/letter/dto/response/LetterListResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/dto/response/LetterListResponse.java
@@ -1,9 +1,17 @@
 package com.dearjolly.server.domain.letter.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+@Schema(description = "편지 목록 응답")
 public record LetterListResponse(
+
+        @Schema(description = "편지 목록. 편지가 한 통도 없으면 빈 배열이다",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         List<LetterSummaryResponse> letters,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         boolean hasNext
 ) {
     public static LetterListResponse of(List<LetterSummaryResponse> letters, boolean hasNext) {

--- a/src/main/java/com/dearjolly/server/domain/letter/dto/response/LetterSummaryResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/dto/response/LetterSummaryResponse.java
@@ -26,10 +26,7 @@ public record LetterSummaryResponse(
                 requiredMode = Schema.RequiredMode.REQUIRED)
         Status status,
 
-        @Schema(
-                description = "피드백 열람 여부. FEEDBACK_COMPLETED 이면서 false 면 날짜 앞에 빨간 점을 찍는다",
-                example = "false",
-                requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "피드백 열람 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
         boolean isRead,
 
         @Schema(

--- a/src/main/java/com/dearjolly/server/domain/letter/dto/response/LetterSummaryResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/dto/response/LetterSummaryResponse.java
@@ -2,14 +2,40 @@ package com.dearjolly.server.domain.letter.dto.response;
 
 import com.dearjolly.server.domain.letter.entity.Letters;
 import com.dearjolly.server.domain.letter.enums.Status;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
+@Schema(description = "편지 목록의 카드 한 장")
 public record LetterSummaryResponse(
+
+        @Schema(description = "편지 ID", example = "15", requiredMode = Schema.RequiredMode.REQUIRED)
         Long letterId,
+
+        @Schema(description = "편지 날짜", example = "2025-11-01", requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDate date,
+
+        @Schema(
+                description = "편지 미리보기. 원문 앞 50자이며 말줄임은 앱에서 처리한다",
+                example = "I got flowers from a friend today. It really touch",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         String summary,
+
+        @Schema(
+                description = "편지 상태",
+                allowableValues = {"SUBMITTED", "FEEDBACK_IN_PROGRESS", "FEEDBACK_COMPLETED"},
+                requiredMode = Schema.RequiredMode.REQUIRED)
         Status status,
+
+        @Schema(
+                description = "피드백 열람 여부. FEEDBACK_COMPLETED 이면서 false 면 날짜 앞에 빨간 점을 찍는다",
+                example = "false",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         boolean isRead,
+
+        @Schema(
+                description = "우표 이미지 URL. 항상 값이 있으며, 피드백 완료 전에는 soon(준비 중) 우표다",
+                example = "http://localhost:9000/dear-jolly-stamps/stamp/soon.png",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         String stampImage
 ) {
     private static final int SUMMARY_LENGTH = 50;

--- a/src/main/java/com/dearjolly/server/domain/letter/enums/LetterSort.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/enums/LetterSort.java
@@ -1,9 +1,11 @@
 package com.dearjolly.server.domain.letter.enums;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 
+@Schema(description = "편지 목록 정렬 기준. 기준은 편지 날짜이며, 같은 날짜면 LATEST 는 나중에 쓴 편지가 먼저 온다")
 @Getter
 @RequiredArgsConstructor
 public enum LetterSort {

--- a/src/main/java/com/dearjolly/server/domain/letter/enums/LetterSort.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/enums/LetterSort.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 
-@Schema(description = "편지 목록 정렬 기준. 기준은 편지 날짜이며, 같은 날짜면 LATEST 는 나중에 쓴 편지가 먼저 온다")
+@Schema(description = "편지 목록 정렬 기준 (편지 날짜 기준)")
 @Getter
 @RequiredArgsConstructor
 public enum LetterSort {

--- a/src/main/java/com/dearjolly/server/domain/letter/enums/Status.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/enums/Status.java
@@ -1,8 +1,10 @@
 package com.dearjolly.server.domain.letter.enums;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Schema(description = "편지 상태. 앱은 SUBMITTED 와 FEEDBACK_IN_PROGRESS 를 동일하게 렌더링한다")
 @Getter
 @RequiredArgsConstructor
 public enum Status {

--- a/src/main/java/com/dearjolly/server/domain/user/controller/AuthController.java
+++ b/src/main/java/com/dearjolly/server/domain/user/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.dearjolly.server.domain.user.controller;
 
+import static org.springframework.http.HttpStatus.FOUND;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -10,8 +11,14 @@ import com.dearjolly.server.domain.user.enums.OauthProvider;
 import com.dearjolly.server.domain.user.service.AuthService;
 import com.dearjolly.server.global.auth.oauth.OauthProperties;
 import com.dearjolly.server.global.auth.principal.LoginUser;
+import com.dearjolly.server.global.exception.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -28,7 +35,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
-@Tag(name = "인증", description = "소셜 로그인, 토큰 재발급, 로그아웃 API")
+@Tag(name = "인증", description = """
+        소셜 로그인, 토큰 재발급, 로그아웃 API.
+
+        로그인은 **서버 리다이렉트 방식**이다. 앱은 로그인 시작 주소를 열기만 하고, 코드 교환 · 회원 생성 · 토큰 발급은 서버가 한다.
+        앱 SDK 로 받은 소셜 토큰을 서버에 전달하는 방식은 지원하지 않는다. 콜백 2종은 카카오 · 애플이 호출하는 주소로, 앱이 직접 호출하지 않는다.""")
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -36,7 +47,27 @@ public class AuthController {
     private final AuthService authService;
     private final OauthProperties oauthProperties;
 
-    @Operation(summary = "소셜 로그인 시작 - provider 로그인 페이지로 리다이렉트")
+    @Operation(
+            summary = "소셜 로그인 시작 - provider 로그인 페이지로 리다이렉트",
+            description = """
+                    소셜 로그인을 시작한다. 앱은 이 주소를 외부 브라우저 또는 웹뷰로 열기만 하면 되고, 서버가 provider 로그인 페이지로 보내준다.
+
+                    앱이 할 일은 세 가지다. **① 이 주소를 연다 → ② 열린 페이지에서 유저가 로그인한다 → ③ 딥링크로 토큰을 받는다.**
+
+                    - 유저는 `(provider + provider 회원 식별자)` 로 구분한다. 이메일이 같아도 카카오와 애플은 별개 계정이다.
+                    - `provider` 는 대소문자를 가리지 않는다. `kakao` · `Kakao` · `KAKAO` 가 모두 같다.
+                    - `KAKAO` · `APPLE` 중 어느 것도 아니면 `COMMON_001` 이다.""")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "302",
+                    description = "provider 로그인 페이지로 리다이렉트한다. `Location` 헤더를 따라간다",
+                    content = @Content),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "`COMMON_001` 지원하지 않는 provider",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @SecurityRequirements
     @GetMapping("/{provider}")
     public ResponseEntity<Void> authorize(
             @Parameter(description = "로그인 수단 (KAKAO, APPLE) - 대소문자를 가리지 않는다", required = true)
@@ -44,12 +75,52 @@ public class AuthController {
     ) {
         String state = UUID.randomUUID().toString();
         return ResponseEntity
-                .status(org.springframework.http.HttpStatus.FOUND)
+                .status(FOUND)
                 .location(URI.create(authService.buildAuthorizationUri(provider, state)))
                 .build();
     }
 
-    @Operation(summary = "카카오 로그인 콜백 - 코드 교환 후 앱 딥링크로 리다이렉트")
+    @Operation(
+            summary = "카카오 로그인 콜백 - 코드 교환 후 앱 딥링크로 리다이렉트",
+            description = """
+                    **카카오가 호출하는 주소다. 앱이 직접 호출하지 않는다.** 서버가 회원을 찾거나 새로 만들고,
+                    JWT 와 온보딩 상태를 앱 딥링크(`dearjolly://auth/callback`)의 쿼리 파라미터로 돌려준다.
+
+                    **딥링크로 실려 오는 값**
+                    - `accessToken` (String): 액세스 토큰 (30분)
+                    - `refreshToken` (String): 리프레시 토큰 (14일)
+                    - `userId` (Long): 유저 ID
+                    - `isNewUser` (Boolean): 이번 로그인으로 가입된 신규 유저인지 여부
+                    - `termsAgreed` (Boolean): 필수 약관 동의 완료 여부
+                    - `nicknameRegistered` (Boolean): 닉네임 등록 여부
+
+                    **앱의 진입 화면 분기**
+                    - `termsAgreed == false` → 약관동의 화면
+                    - `termsAgreed == true` 이고 `nicknameRegistered == false` → 닉네임 화면
+                    - 둘 다 `true` → 홈
+
+                    **주의**
+                    - **토큰이 URL 에 실려 오므로** 딥링크를 받은 즉시 보안 저장소(iOS Keychain / Android EncryptedSharedPreferences)로 옮기고,
+                      웹뷰를 썼다면 히스토리를 비운다.
+                    - 가입 직후에는 약관 동의 이력이 없고 닉네임이 비어 있다.
+                    - 로그인은 **기기 1대만 유지**된다. 새로 로그인하면 이전 로그인은 풀린다.
+                    - **탈퇴한 계정으로 다시 로그인하면 항상 신규 가입**(`isNewUser=true`)이며, 이전 편지는 복원되지 않는다.
+                    - 콜백 단계의 실패는 딥링크가 아니라 **JSON 에러 응답**으로 나간다.""")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "302",
+                    description = "JWT 와 온보딩 상태를 쿼리 파라미터에 실어 앱 딥링크로 리다이렉트한다",
+                    content = @Content),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "`AUTH_002` 인가 코드 검증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(
+                    responseCode = "502",
+                    description = "`AUTH_003` 카카오 서버와 통신 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @SecurityRequirements
     @GetMapping("/kakao/callback")
     public ResponseEntity<Void> kakaoCallback(
             @Parameter(description = "카카오가 발급한 인가 코드", required = true)
@@ -58,7 +129,31 @@ public class AuthController {
         return redirectToApp(authService.handleCallback(OauthProvider.KAKAO, code, null));
     }
 
-    @Operation(summary = "애플 로그인 콜백 - 코드 교환 후 앱 딥링크로 리다이렉트")
+    @Operation(
+            summary = "애플 로그인 콜백 - 코드 교환 후 앱 딥링크로 리다이렉트",
+            description = """
+                    **애플이 호출하는 주소다. 앱이 직접 호출하지 않는다.** 애플이 `form_post` 로 보내기 때문에 `POST` 이며,
+                    요청 형식은 `application/x-www-form-urlencoded` 다.
+
+                    응답 형태와 앱 분기 규칙은 카카오 콜백과 완전히 같다.
+
+                    - 애플에서 이메일 제공을 거부한 유저는 **이메일이 비어 있다**(`null`). 서버가 대체 주소를 지어내지 않는다.
+                    - 인가 코드 · `id_token` 검증에 실패하면 `AUTH_002`, 애플 서버와 통신하지 못하면 `AUTH_003` 이다.""")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "302",
+                    description = "카카오 콜백과 동일한 파라미터로 앱 딥링크에 리다이렉트한다",
+                    content = @Content),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "`AUTH_002` 인가 코드 · id_token 검증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(
+                    responseCode = "502",
+                    description = "`AUTH_003` 애플 서버와 통신 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @SecurityRequirements
     @PostMapping("/apple/callback")
     public ResponseEntity<Void> appleCallback(
             @Parameter(description = "애플이 발급한 인가 코드", required = true)
@@ -69,7 +164,24 @@ public class AuthController {
         return redirectToApp(authService.handleCallback(OauthProvider.APPLE, code, idToken));
     }
 
-    @Operation(summary = "토큰 재발급")
+    @Operation(
+            summary = "토큰 재발급",
+            description = """
+                    리프레시 토큰으로 액세스 토큰을 재발급한다.
+
+                    - **리프레시 토큰도 함께 새로 발급되고 이전 토큰은 즉시 무효**가 되므로, 앱은 응답의 두 토큰을 모두 갈아 끼운다.
+                    - 액세스 토큰 30분, 리프레시 토큰 14일이다.
+                    - **같은 리프레시 토큰을 두 번 쓸 수 없다.** 만료됐거나 위조됐거나 이미 사용된 값이면 `AUTH_004` 다.
+                    - **만료된 액세스 토큰이 헤더에 실려 있어도 정상 동작한다.** 앱의 토큰 인터셉터가 모든 요청에 헤더를 붙여도 문제없다.
+                    - 앱은 `AUTH_004` 를 받으면 저장된 토큰을 지우고 로그인 화면으로 이동한다.""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "재발급 성공. 두 토큰을 모두 교체 저장한다"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "`AUTH_004` 만료 · 위조 · 이미 사용된 리프레시 토큰",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @SecurityRequirements
     @PostMapping("/reissue")
     public ResponseEntity<ReissueResponse> reissue(
             @Parameter(description = "재발급 요청 객체", required = true)
@@ -80,7 +192,21 @@ public class AuthController {
                 .body(authService.reissue(request));
     }
 
-    @Operation(summary = "로그아웃")
+    @Operation(
+            summary = "로그아웃",
+            description = """
+                    로그아웃한다. **세션만 끊고 편지 · 계정 데이터는 그대로 보존**된다.
+
+                    - 카카오 세션 종료 등 소셜 로그아웃은 앱 SDK 에서 처리한다.
+                    - 온보딩 미완료 상태에서도 호출할 수 있다.
+                    - 실패는 공통 인증 오류(`AUTH_005` · `AUTH_007`)뿐이다.""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "로그아웃 성공. Refresh Token 이 무효화된다"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "`AUTH_005` 유효하지 않은 토큰 / `AUTH_007` 탈퇴한 계정",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@LoginUser Long userId) {
         authService.logout(userId);
@@ -102,7 +228,7 @@ public class AuthController {
                 .toUri();
 
         return ResponseEntity
-                .status(org.springframework.http.HttpStatus.FOUND)
+                .status(FOUND)
                 .location(target)
                 .build();
     }

--- a/src/main/java/com/dearjolly/server/domain/user/controller/AuthController.java
+++ b/src/main/java/com/dearjolly/server/domain/user/controller/AuthController.java
@@ -39,7 +39,7 @@ public class AuthController {
     @Operation(summary = "소셜 로그인 시작 - provider 로그인 페이지로 리다이렉트")
     @GetMapping("/{provider}")
     public ResponseEntity<Void> authorize(
-            @Parameter(description = "로그인 수단 (KAKAO, APPLE)", required = true)
+            @Parameter(description = "로그인 수단 (KAKAO, APPLE) - 대소문자를 가리지 않는다", required = true)
             @PathVariable OauthProvider provider
     ) {
         String state = UUID.randomUUID().toString();

--- a/src/main/java/com/dearjolly/server/domain/user/controller/AuthController.java
+++ b/src/main/java/com/dearjolly/server/domain/user/controller/AuthController.java
@@ -35,11 +35,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
-@Tag(name = "인증", description = """
-        소셜 로그인, 토큰 재발급, 로그아웃 API.
-
-        로그인은 **서버 리다이렉트 방식**이다. 앱은 로그인 시작 주소를 열기만 하고, 코드 교환 · 회원 생성 · 토큰 발급은 서버가 한다.
-        앱 SDK 로 받은 소셜 토큰을 서버에 전달하는 방식은 지원하지 않는다. 콜백 2종은 카카오 · 애플이 호출하는 주소로, 앱이 직접 호출하지 않는다.""")
+@Tag(name = "인증", description = "소셜 로그인, 토큰 재발급, 로그아웃 API. 로그인은 서버 리다이렉트 방식이며 콜백 2종은 앱이 직접 호출하지 않는다.")
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -50,18 +46,12 @@ public class AuthController {
     @Operation(
             summary = "소셜 로그인 시작 - provider 로그인 페이지로 리다이렉트",
             description = """
-                    소셜 로그인을 시작한다. 앱은 이 주소를 외부 브라우저 또는 웹뷰로 열기만 하면 되고, 서버가 provider 로그인 페이지로 보내준다.
+                    앱은 이 주소를 외부 브라우저 또는 웹뷰로 열기만 한다. 코드 교환 · 회원 생성 · 토큰 발급은 서버가 처리한다.
 
-                    앱이 할 일은 세 가지다. **① 이 주소를 연다 → ② 열린 페이지에서 유저가 로그인한다 → ③ 딥링크로 토큰을 받는다.**
-
-                    - 유저는 `(provider + provider 회원 식별자)` 로 구분한다. 이메일이 같아도 카카오와 애플은 별개 계정이다.
-                    - `provider` 는 대소문자를 가리지 않는다. `kakao` · `Kakao` · `KAKAO` 가 모두 같다.
-                    - `KAKAO` · `APPLE` 중 어느 것도 아니면 `COMMON_001` 이다.""")
+                    - `provider` 는 대소문자를 가리지 않는다.
+                    - 유저는 `(provider + provider 회원 식별자)` 로 구분한다. 이메일이 같아도 카카오와 애플은 별개 계정이다.""")
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "302",
-                    description = "provider 로그인 페이지로 리다이렉트한다. `Location` 헤더를 따라간다",
-                    content = @Content),
+            @ApiResponse(responseCode = "302", description = "provider 로그인 페이지로 리다이렉트", content = @Content),
             @ApiResponse(
                     responseCode = "400",
                     description = "`COMMON_001` 지원하지 않는 provider",
@@ -83,34 +73,15 @@ public class AuthController {
     @Operation(
             summary = "카카오 로그인 콜백 - 코드 교환 후 앱 딥링크로 리다이렉트",
             description = """
-                    **카카오가 호출하는 주소다. 앱이 직접 호출하지 않는다.** 서버가 회원을 찾거나 새로 만들고,
-                    JWT 와 온보딩 상태를 앱 딥링크(`dearjolly://auth/callback`)의 쿼리 파라미터로 돌려준다.
+                    **카카오가 호출하는 주소다. 앱이 직접 호출하지 않는다.**
+                    앱 딥링크에 `accessToken` · `refreshToken` · `userId` · `isNewUser` · `termsAgreed` · `nicknameRegistered` 를 실어 보낸다.
 
-                    **딥링크로 실려 오는 값**
-                    - `accessToken` (String): 액세스 토큰 (30분)
-                    - `refreshToken` (String): 리프레시 토큰 (14일)
-                    - `userId` (Long): 유저 ID
-                    - `isNewUser` (Boolean): 이번 로그인으로 가입된 신규 유저인지 여부
-                    - `termsAgreed` (Boolean): 필수 약관 동의 완료 여부
-                    - `nicknameRegistered` (Boolean): 닉네임 등록 여부
-
-                    **앱의 진입 화면 분기**
-                    - `termsAgreed == false` → 약관동의 화면
-                    - `termsAgreed == true` 이고 `nicknameRegistered == false` → 닉네임 화면
-                    - 둘 다 `true` → 홈
-
-                    **주의**
-                    - **토큰이 URL 에 실려 오므로** 딥링크를 받은 즉시 보안 저장소(iOS Keychain / Android EncryptedSharedPreferences)로 옮기고,
-                      웹뷰를 썼다면 히스토리를 비운다.
-                    - 가입 직후에는 약관 동의 이력이 없고 닉네임이 비어 있다.
-                    - 로그인은 **기기 1대만 유지**된다. 새로 로그인하면 이전 로그인은 풀린다.
-                    - **탈퇴한 계정으로 다시 로그인하면 항상 신규 가입**(`isNewUser=true`)이며, 이전 편지는 복원되지 않는다.
-                    - 콜백 단계의 실패는 딥링크가 아니라 **JSON 에러 응답**으로 나간다.""")
+                    - 앱 진입 화면은 `termsAgreed == false` → 약관동의, `nicknameRegistered == false` → 닉네임, 둘 다 `true` → 홈이다.
+                    - **토큰이 URL 에 실려 오므로** 받은 즉시 보안 저장소로 옮긴다.
+                    - 로그인은 **기기 1대만 유지**된다. 탈퇴한 계정으로 다시 로그인하면 항상 신규 가입이다.
+                    - 이 단계의 실패는 딥링크가 아니라 JSON 에러 응답으로 나간다.""")
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "302",
-                    description = "JWT 와 온보딩 상태를 쿼리 파라미터에 실어 앱 딥링크로 리다이렉트한다",
-                    content = @Content),
+            @ApiResponse(responseCode = "302", description = "앱 딥링크로 리다이렉트", content = @Content),
             @ApiResponse(
                     responseCode = "401",
                     description = "`AUTH_002` 인가 코드 검증 실패",
@@ -132,18 +103,12 @@ public class AuthController {
     @Operation(
             summary = "애플 로그인 콜백 - 코드 교환 후 앱 딥링크로 리다이렉트",
             description = """
-                    **애플이 호출하는 주소다. 앱이 직접 호출하지 않는다.** 애플이 `form_post` 로 보내기 때문에 `POST` 이며,
-                    요청 형식은 `application/x-www-form-urlencoded` 다.
+                    **애플이 호출하는 주소다. 앱이 직접 호출하지 않는다.** 애플이 `form_post` 로 보내기 때문에 `POST` 다.
 
-                    응답 형태와 앱 분기 규칙은 카카오 콜백과 완전히 같다.
-
-                    - 애플에서 이메일 제공을 거부한 유저는 **이메일이 비어 있다**(`null`). 서버가 대체 주소를 지어내지 않는다.
-                    - 인가 코드 · `id_token` 검증에 실패하면 `AUTH_002`, 애플 서버와 통신하지 못하면 `AUTH_003` 이다.""")
+                    - 응답 형태와 앱 분기 규칙은 카카오 콜백과 같다.
+                    - 애플에서 이메일 제공을 거부한 유저는 이메일이 `null` 이다.""")
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "302",
-                    description = "카카오 콜백과 동일한 파라미터로 앱 딥링크에 리다이렉트한다",
-                    content = @Content),
+            @ApiResponse(responseCode = "302", description = "앱 딥링크로 리다이렉트", content = @Content),
             @ApiResponse(
                     responseCode = "401",
                     description = "`AUTH_002` 인가 코드 · id_token 검증 실패",
@@ -167,15 +132,11 @@ public class AuthController {
     @Operation(
             summary = "토큰 재발급",
             description = """
-                    리프레시 토큰으로 액세스 토큰을 재발급한다.
-
-                    - **리프레시 토큰도 함께 새로 발급되고 이전 토큰은 즉시 무효**가 되므로, 앱은 응답의 두 토큰을 모두 갈아 끼운다.
-                    - 액세스 토큰 30분, 리프레시 토큰 14일이다.
-                    - **같은 리프레시 토큰을 두 번 쓸 수 없다.** 만료됐거나 위조됐거나 이미 사용된 값이면 `AUTH_004` 다.
-                    - **만료된 액세스 토큰이 헤더에 실려 있어도 정상 동작한다.** 앱의 토큰 인터셉터가 모든 요청에 헤더를 붙여도 문제없다.
+                    - **리프레시 토큰도 함께 새로 발급되고 이전 토큰은 즉시 무효**가 된다. 앱은 응답의 두 토큰을 모두 갈아 끼운다.
+                    - 만료된 액세스 토큰이 헤더에 실려 있어도 정상 동작한다.
                     - 앱은 `AUTH_004` 를 받으면 저장된 토큰을 지우고 로그인 화면으로 이동한다.""")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "재발급 성공. 두 토큰을 모두 교체 저장한다"),
+            @ApiResponse(responseCode = "200", description = "재발급 성공"),
             @ApiResponse(
                     responseCode = "401",
                     description = "`AUTH_004` 만료 · 위조 · 이미 사용된 리프레시 토큰",
@@ -195,13 +156,12 @@ public class AuthController {
     @Operation(
             summary = "로그아웃",
             description = """
-                    로그아웃한다. **세션만 끊고 편지 · 계정 데이터는 그대로 보존**된다.
+                    **세션만 끊고 편지 · 계정 데이터는 그대로 보존**된다.
 
                     - 카카오 세션 종료 등 소셜 로그아웃은 앱 SDK 에서 처리한다.
-                    - 온보딩 미완료 상태에서도 호출할 수 있다.
-                    - 실패는 공통 인증 오류(`AUTH_005` · `AUTH_007`)뿐이다.""")
+                    - 온보딩 미완료 상태에서도 호출할 수 있다.""")
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "로그아웃 성공. Refresh Token 이 무효화된다"),
+            @ApiResponse(responseCode = "204", description = "로그아웃 성공"),
             @ApiResponse(
                     responseCode = "401",
                     description = "`AUTH_005` 유효하지 않은 토큰 / `AUTH_007` 탈퇴한 계정",

--- a/src/main/java/com/dearjolly/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/dearjolly/server/domain/user/controller/UserController.java
@@ -10,8 +10,14 @@ import com.dearjolly.server.domain.user.dto.response.TermsAgreeResponse;
 import com.dearjolly.server.domain.user.dto.response.UserGetResponse;
 import com.dearjolly.server.domain.user.service.UserService;
 import com.dearjolly.server.global.auth.principal.LoginUser;
+import com.dearjolly.server.global.exception.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,14 +30,54 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "사용자", description = "약관 동의, 계정 조회, 탈퇴, 닉네임 설정 API")
+@Tag(name = "사용자", description = """
+        약관 동의, 계정 조회, 탈퇴, 닉네임 설정 API.
+
+        온보딩(필수 약관 2종 동의 + 닉네임 등록)을 구성하는 API 이므로 **네 개 모두 온보딩 가드를 통과한다.**
+        온보딩을 마치지 않은 유저도 호출할 수 있다.
+
+        실패는 각 API 에 적힌 코드와 공통 인증 오류(`AUTH_005` · `AUTH_007`)뿐이다.""")
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
 
-    @Operation(summary = "약관 동의 및 마케팅 동의 철회")
+    @Operation(
+            summary = "약관 동의 및 마케팅 동의 철회",
+            description = """
+                    약관 동의 내역을 저장한다. 온보딩 약관 동의와 설정 화면의 마케팅 동의 철회가 **같은 API** 를 쓴다.
+
+                    - 약관은 3종이다. **`SERVICE`(서비스 이용약관) · `PRIVACY`(개인정보 처리방침)는 필수, `MARKETING`(마케팅 정보 수신)은 선택**이다.
+                    - 마케팅에 동의하지 않아도 서비스 이용에 제한이 없다.
+                    - 필수 2건이 모두 동의 상태가 아니면 `USER_002` 이며, **이때 그 요청은 아무것도 저장되지 않는다.**
+                      온보딩에서는 필수 2건을 항상 함께 보낸다.
+                    - **보내지 않은 항목은 그대로 유지된다.** 마케팅만 철회하려면 `MARKETING` 한 건만 보내면 된다.
+                    - **약관이 개정돼도 다시 묻지 않는다.**
+                    - 약관 본문은 이 API 가 주지 않는다. 버전 조회 API 의 웹뷰 링크로 연다.
+                    - 생성이지만 응답은 `201` 이 아니라 `200` 이다.""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "저장 성공. 반영 후의 필수 약관 동의 완료 여부를 돌려준다"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "`USER_002` 필수 약관 미동의 / `COMMON_001` 정의되지 않은 약관 종류 · 바디 형식 오류",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "USER_002",
+                                            value = """
+                                                    {"status": 400, "code": "USER_002", "message": "필수 약관에 모두 동의해야 합니다."}"""),
+                                    @ExampleObject(
+                                            name = "COMMON_001",
+                                            value = """
+                                                    {"status": 400, "code": "COMMON_001", "message": "잘못된 요청입니다."}""")
+                            })),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "`AUTH_005` 유효하지 않은 토큰 / `AUTH_007` 탈퇴한 계정",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @PostMapping("/terms")
     public ResponseEntity<TermsAgreeResponse> agreeTerms(
             @LoginUser Long userId,
@@ -43,7 +89,22 @@ public class UserController {
                 .body(userService.agreeTerms(userId, request));
     }
 
-    @Operation(summary = "계정 정보 조회")
+    @Operation(
+            summary = "계정 정보 조회",
+            description = """
+                    설정 화면에 표시할 계정 정보를 조회한다.
+
+                    - **이메일이 비어 있을 수 있다.** 애플에서 이메일 제공을 거부한 경우이며, 이때 앱은 로그인 수단만 표시한다.
+                    - 온보딩 전에도 호출할 수 있고, 이 경우 `nickname` 이 비어 있다.
+                    - `marketingAgreed` 는 마케팅 동의 이력이 없으면 `false` 다.
+                    - 실패는 공통 인증 오류(`AUTH_005` · `AUTH_007`)뿐이다.""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "`AUTH_005` 유효하지 않은 토큰 / `AUTH_007` 탈퇴한 계정",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping
     public ResponseEntity<UserGetResponse> getUser(@LoginUser Long userId) {
         return ResponseEntity
@@ -51,7 +112,23 @@ public class UserController {
                 .body(userService.getUser(userId));
     }
 
-    @Operation(summary = "회원 탈퇴")
+    @Operation(
+            summary = "회원 탈퇴",
+            description = """
+                    회원 탈퇴를 처리한다. **모든 편지와 계정 정보가 삭제되며 복구할 수 없다.**
+
+                    - 탈퇴 즉시 로그인이 풀린다. 남아 있던 액세스 토큰도 `AUTH_007` 로 거절된다.
+                    - 탈퇴 후 같은 소셜 계정으로 다시 로그인하면 **신규 가입**으로 처리되고, 이전 편지는 돌아오지 않는다.
+                    - 소셜 연결 해제(카카오 unlink / 애플 revoke)는 서버가 처리한다. **앱이 인가 코드를 따로 보낼 필요가 없다.**
+                    - 온보딩 미완료 상태에서도 탈퇴할 수 있다.
+                    - 실패는 공통 인증 오류(`AUTH_005` · `AUTH_007`)뿐이다.""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "탈퇴 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "`AUTH_005` 유효하지 않은 토큰 / `AUTH_007` 탈퇴한 계정",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @DeleteMapping
     public ResponseEntity<Void> withdraw(@LoginUser Long userId) {
         userService.withdraw(userId);
@@ -60,7 +137,48 @@ public class UserController {
                 .build();
     }
 
-    @Operation(summary = "닉네임 등록 및 변경")
+    @Operation(
+            summary = "닉네임 등록 및 변경",
+            description = """
+                    닉네임을 등록하거나 변경한다. 온보딩(이름 입력)과 설정(이름 변경)이 **같은 API** 를 쓴다.
+
+                    - **영문 · 숫자 1~20자만** 허용한다. 공백 · 특수기호 · 한글은 불가다.
+                    - 길이는 **문자 수** 기준이라 앱의 `10/20` 카운터와 일치한다.
+                    - **중복을 허용한다.** 같은 닉네임을 써도 에러가 나지 않는다.
+                    - 변경 횟수 제한이 없다.
+
+                    **검증 순서** — **길이를 먼저 보고 통과하면 문자를 본다.** 두 조건을 동시에 어겨도 에러는 하나만 내려간다.
+                    21자 한글은 `USER_003` 이 아니라 `USER_004` 다.
+
+                    | 순서 | 규칙 | 값 | code |
+                    | --- | --- | --- | --- |
+                    | 1 | 길이 | 1 ~ 20자 (문자 수). `null` · `""` 는 0자로 본다 | `USER_004` |
+                    | 2 | 허용 문자 | 영문 + 숫자 (`^[A-Za-z0-9]+$`) | `USER_003` |
+
+                    앱은 사유별 문구(`공백을 포함할 수 없어요` / `특수 기호를 포함할 수 없어요` / `한글을 포함할 수 없어요`)를
+                    클라이언트에서 판별해 표시한다. 서버는 최종 방어선이다.""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "`USER_004` 길이 위반 / `USER_003` 허용하지 않는 문자",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "USER_004",
+                                            value = """
+                                                    {"status": 400, "code": "USER_004", "message": "닉네임은 1자 이상 20자 이하여야 합니다."}"""),
+                                    @ExampleObject(
+                                            name = "USER_003",
+                                            value = """
+                                                    {"status": 400, "code": "USER_003", "message": "닉네임은 공백, 특수기호, 한글 없이 작성해야 합니다."}""")
+                            })),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "`AUTH_005` 유효하지 않은 토큰 / `AUTH_007` 탈퇴한 계정",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @PatchMapping("/nickname")
     public ResponseEntity<NicknameUpdateResponse> updateNickname(
             @LoginUser Long userId,

--- a/src/main/java/com/dearjolly/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/dearjolly/server/domain/user/controller/UserController.java
@@ -30,13 +30,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "사용자", description = """
-        약관 동의, 계정 조회, 탈퇴, 닉네임 설정 API.
-
-        온보딩(필수 약관 2종 동의 + 닉네임 등록)을 구성하는 API 이므로 **네 개 모두 온보딩 가드를 통과한다.**
-        온보딩을 마치지 않은 유저도 호출할 수 있다.
-
-        실패는 각 API 에 적힌 코드와 공통 인증 오류(`AUTH_005` · `AUTH_007`)뿐이다.""")
+@Tag(name = "사용자", description = "약관 동의, 계정 조회, 탈퇴, 닉네임 설정 API. 온보딩을 구성하므로 네 개 모두 온보딩 전에 호출할 수 있다.")
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -46,18 +40,14 @@ public class UserController {
     @Operation(
             summary = "약관 동의 및 마케팅 동의 철회",
             description = """
-                    약관 동의 내역을 저장한다. 온보딩 약관 동의와 설정 화면의 마케팅 동의 철회가 **같은 API** 를 쓴다.
+                    온보딩 약관 동의와 설정 화면의 마케팅 동의 철회가 같은 API 를 쓴다.
 
-                    - 약관은 3종이다. **`SERVICE`(서비스 이용약관) · `PRIVACY`(개인정보 처리방침)는 필수, `MARKETING`(마케팅 정보 수신)은 선택**이다.
-                    - 마케팅에 동의하지 않아도 서비스 이용에 제한이 없다.
+                    - **`SERVICE` · `PRIVACY` 는 필수, `MARKETING` 은 선택**이다.
+                    - **보내지 않은 항목은 그대로 유지된다.** 마케팅만 철회하려면 `MARKETING` 한 건만 보낸다.
                     - 필수 2건이 모두 동의 상태가 아니면 `USER_002` 이며, **이때 그 요청은 아무것도 저장되지 않는다.**
-                      온보딩에서는 필수 2건을 항상 함께 보낸다.
-                    - **보내지 않은 항목은 그대로 유지된다.** 마케팅만 철회하려면 `MARKETING` 한 건만 보내면 된다.
-                    - **약관이 개정돼도 다시 묻지 않는다.**
-                    - 약관 본문은 이 API 가 주지 않는다. 버전 조회 API 의 웹뷰 링크로 연다.
-                    - 생성이지만 응답은 `201` 이 아니라 `200` 이다.""")
+                    - 약관이 개정돼도 다시 묻지 않는다.""")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "저장 성공. 반영 후의 필수 약관 동의 완료 여부를 돌려준다"),
+            @ApiResponse(responseCode = "200", description = "저장 성공"),
             @ApiResponse(
                     responseCode = "400",
                     description = "`USER_002` 필수 약관 미동의 / `COMMON_001` 정의되지 않은 약관 종류 · 바디 형식 오류",
@@ -94,10 +84,8 @@ public class UserController {
             description = """
                     설정 화면에 표시할 계정 정보를 조회한다.
 
-                    - **이메일이 비어 있을 수 있다.** 애플에서 이메일 제공을 거부한 경우이며, 이때 앱은 로그인 수단만 표시한다.
-                    - 온보딩 전에도 호출할 수 있고, 이 경우 `nickname` 이 비어 있다.
-                    - `marketingAgreed` 는 마케팅 동의 이력이 없으면 `false` 다.
-                    - 실패는 공통 인증 오류(`AUTH_005` · `AUTH_007`)뿐이다.""")
+                    - 온보딩 전에는 `nickname` 이, 애플에서 이메일 제공을 거부했으면 `email` 이 `null` 이다.
+                    - `marketingAgreed` 는 동의 이력이 없으면 `false` 다.""")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(
@@ -115,13 +103,11 @@ public class UserController {
     @Operation(
             summary = "회원 탈퇴",
             description = """
-                    회원 탈퇴를 처리한다. **모든 편지와 계정 정보가 삭제되며 복구할 수 없다.**
+                    **모든 편지와 계정 정보가 삭제되며 복구할 수 없다.**
 
-                    - 탈퇴 즉시 로그인이 풀린다. 남아 있던 액세스 토큰도 `AUTH_007` 로 거절된다.
-                    - 탈퇴 후 같은 소셜 계정으로 다시 로그인하면 **신규 가입**으로 처리되고, 이전 편지는 돌아오지 않는다.
-                    - 소셜 연결 해제(카카오 unlink / 애플 revoke)는 서버가 처리한다. **앱이 인가 코드를 따로 보낼 필요가 없다.**
-                    - 온보딩 미완료 상태에서도 탈퇴할 수 있다.
-                    - 실패는 공통 인증 오류(`AUTH_005` · `AUTH_007`)뿐이다.""")
+                    - 탈퇴 즉시 로그인이 풀리고, 남아 있던 액세스 토큰도 `AUTH_007` 로 거절된다.
+                    - 같은 소셜 계정으로 다시 로그인하면 신규 가입으로 처리된다.
+                    - 소셜 연결 해제(카카오 unlink / 애플 revoke)는 서버가 처리한다. **앱이 인가 코드를 따로 보낼 필요가 없다.**""")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "탈퇴 성공"),
             @ApiResponse(
@@ -140,23 +126,10 @@ public class UserController {
     @Operation(
             summary = "닉네임 등록 및 변경",
             description = """
-                    닉네임을 등록하거나 변경한다. 온보딩(이름 입력)과 설정(이름 변경)이 **같은 API** 를 쓴다.
+                    온보딩(이름 입력)과 설정(이름 변경)이 같은 API 를 쓴다.
 
-                    - **영문 · 숫자 1~20자만** 허용한다. 공백 · 특수기호 · 한글은 불가다.
-                    - 길이는 **문자 수** 기준이라 앱의 `10/20` 카운터와 일치한다.
-                    - **중복을 허용한다.** 같은 닉네임을 써도 에러가 나지 않는다.
-                    - 변경 횟수 제한이 없다.
-
-                    **검증 순서** — **길이를 먼저 보고 통과하면 문자를 본다.** 두 조건을 동시에 어겨도 에러는 하나만 내려간다.
-                    21자 한글은 `USER_003` 이 아니라 `USER_004` 다.
-
-                    | 순서 | 규칙 | 값 | code |
-                    | --- | --- | --- | --- |
-                    | 1 | 길이 | 1 ~ 20자 (문자 수). `null` · `""` 는 0자로 본다 | `USER_004` |
-                    | 2 | 허용 문자 | 영문 + 숫자 (`^[A-Za-z0-9]+$`) | `USER_003` |
-
-                    앱은 사유별 문구(`공백을 포함할 수 없어요` / `특수 기호를 포함할 수 없어요` / `한글을 포함할 수 없어요`)를
-                    클라이언트에서 판별해 표시한다. 서버는 최종 방어선이다.""")
+                    - **영문 · 숫자 1~20자만** 허용한다. 길이는 문자 수 기준이며 중복을 허용한다.
+                    - **길이를 먼저 보고 통과하면 문자를 본다.** 두 조건을 동시에 어겨도 에러는 하나만 내려간다 — 21자 한글은 `USER_004` 다.""")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경 성공"),
             @ApiResponse(

--- a/src/main/java/com/dearjolly/server/domain/user/dto/request/NicknameUpdateRequest.java
+++ b/src/main/java/com/dearjolly/server/domain/user/dto/request/NicknameUpdateRequest.java
@@ -1,6 +1,14 @@
 package com.dearjolly.server.domain.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "닉네임 등록 · 변경 요청")
 public record NicknameUpdateRequest(
+
+        @Schema(
+                description = "변경할 닉네임. 영문 + 숫자 1~20자 (문자 수). 공백 · 특수기호 · 한글은 불가하며 중복은 허용한다",
+                example = "iloveJolly",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         String nickname
 ) {
 }

--- a/src/main/java/com/dearjolly/server/domain/user/dto/request/ReissueRequest.java
+++ b/src/main/java/com/dearjolly/server/domain/user/dto/request/ReissueRequest.java
@@ -1,9 +1,15 @@
 package com.dearjolly.server.domain.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "토큰 재발급 요청")
 public record ReissueRequest(
 
+        @Schema(
+                description = "로그인 시 발급받은 리프레시 토큰. 한 번 쓰면 무효가 된다",
+                example = "eyJhbGciOiJIUzI1NiJ9...",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "리프레시 토큰은 필수입니다.")
         String refreshToken
 ) {

--- a/src/main/java/com/dearjolly/server/domain/user/dto/request/ReissueRequest.java
+++ b/src/main/java/com/dearjolly/server/domain/user/dto/request/ReissueRequest.java
@@ -6,8 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 @Schema(description = "토큰 재발급 요청")
 public record ReissueRequest(
 
-        @Schema(
-                description = "로그인 시 발급받은 리프레시 토큰. 한 번 쓰면 무효가 된다",
+        @Schema(description = "로그인 시 발급받은 리프레시 토큰. 한 번 쓰면 무효가 된다",
                 example = "eyJhbGciOiJIUzI1NiJ9...",
                 requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "리프레시 토큰은 필수입니다.")

--- a/src/main/java/com/dearjolly/server/domain/user/dto/request/TermsAgreeRequest.java
+++ b/src/main/java/com/dearjolly/server/domain/user/dto/request/TermsAgreeRequest.java
@@ -1,22 +1,29 @@
 package com.dearjolly.server.domain.user.dto.request;
 
 import com.dearjolly.server.domain.user.enums.TermsType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
+@Schema(description = "약관 동의 요청. 보내지 않은 항목은 그대로 유지된다")
 public record TermsAgreeRequest(
 
+        @Schema(description = "약관 동의 목록 (1개 이상)", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotEmpty(message = "약관 동의 목록은 비어 있을 수 없습니다.")
         @Valid
         List<Agreement> agreements
 ) {
+    @Schema(description = "약관 한 건의 동의 여부")
     public record Agreement(
 
+            @Schema(description = "약관 종류. SERVICE · PRIVACY 는 필수, MARKETING 은 선택",
+                    requiredMode = Schema.RequiredMode.REQUIRED)
             @NotNull(message = "약관 종류는 필수입니다.")
             TermsType type,
 
+            @Schema(description = "동의 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
             @NotNull(message = "동의 여부는 필수입니다.")
             Boolean agreed
     ) {

--- a/src/main/java/com/dearjolly/server/domain/user/dto/response/NicknameUpdateResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/user/dto/response/NicknameUpdateResponse.java
@@ -1,8 +1,12 @@
 package com.dearjolly.server.domain.user.dto.response;
 
 import com.dearjolly.server.domain.user.entity.Users;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "닉네임 등록 · 변경 응답")
 public record NicknameUpdateResponse(
+
+        @Schema(description = "변경된 닉네임", example = "iloveJolly", requiredMode = Schema.RequiredMode.REQUIRED)
         String nickname
 ) {
     public static NicknameUpdateResponse from(Users user) {

--- a/src/main/java/com/dearjolly/server/domain/user/dto/response/ReissueResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/user/dto/response/ReissueResponse.java
@@ -1,7 +1,17 @@
 package com.dearjolly.server.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "토큰 재발급 응답. 앱은 두 토큰을 모두 갈아 끼운다")
 public record ReissueResponse(
+
+        @Schema(description = "새 액세스 토큰 (30분)", example = "eyJhbGciOiJIUzI1NiJ9...",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         String accessToken,
+
+        @Schema(description = "새 리프레시 토큰 (14일). 기존 값을 이 값으로 교체 저장한다",
+                example = "eyJhbGciOiJIUzI1NiJ9...",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         String refreshToken
 ) {
     public static ReissueResponse of(String accessToken, String refreshToken) {

--- a/src/main/java/com/dearjolly/server/domain/user/dto/response/TermsAgreeResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/user/dto/response/TermsAgreeResponse.java
@@ -1,6 +1,12 @@
 package com.dearjolly.server.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "약관 동의 응답")
 public record TermsAgreeResponse(
+
+        @Schema(description = "이 요청 반영 후의 필수 약관 동의 완료 여부", example = "true",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         boolean termsAgreed
 ) {
     public static TermsAgreeResponse from(boolean termsAgreed) {

--- a/src/main/java/com/dearjolly/server/domain/user/dto/response/UserGetResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/user/dto/response/UserGetResponse.java
@@ -10,13 +10,10 @@ public record UserGetResponse(
         @Schema(description = "유저 닉네임. 온보딩 전에는 null 이다", example = "ilovesally")
         String nickname,
 
-        @Schema(description = "로그인 수단. 앱에서 아이콘 매핑에 쓴다",
-                requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "로그인 수단", requiredMode = Schema.RequiredMode.REQUIRED)
         OauthProvider provider,
 
-        @Schema(
-                description = "소셜 계정 이메일. 애플에서 이메일 제공을 거부하면 null 이며, 서버가 대체 주소를 지어내지 않는다",
-                example = "kakao_user@email.com")
+        @Schema(description = "소셜 계정 이메일. 애플에서 제공을 거부하면 null 이다", example = "kakao_user@email.com")
         String email,
 
         @Schema(description = "마케팅 수신 동의 여부. 동의 이력이 없으면 false 다", example = "true",

--- a/src/main/java/com/dearjolly/server/domain/user/dto/response/UserGetResponse.java
+++ b/src/main/java/com/dearjolly/server/domain/user/dto/response/UserGetResponse.java
@@ -2,15 +2,25 @@ package com.dearjolly.server.domain.user.dto.response;
 
 import com.dearjolly.server.domain.user.entity.Users;
 import com.dearjolly.server.domain.user.enums.OauthProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * @param nickname 온보딩 전에는 null
- * @param email provider 미제공 시 null /
- */
+@Schema(description = "설정 화면에 표시할 계정 정보")
 public record UserGetResponse(
+
+        @Schema(description = "유저 닉네임. 온보딩 전에는 null 이다", example = "ilovesally")
         String nickname,
+
+        @Schema(description = "로그인 수단. 앱에서 아이콘 매핑에 쓴다",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         OauthProvider provider,
+
+        @Schema(
+                description = "소셜 계정 이메일. 애플에서 이메일 제공을 거부하면 null 이며, 서버가 대체 주소를 지어내지 않는다",
+                example = "kakao_user@email.com")
         String email,
+
+        @Schema(description = "마케팅 수신 동의 여부. 동의 이력이 없으면 false 다", example = "true",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         boolean marketingAgreed
 ) {
     public static UserGetResponse of(Users user, boolean marketingAgreed) {

--- a/src/main/java/com/dearjolly/server/domain/user/enums/OauthProvider.java
+++ b/src/main/java/com/dearjolly/server/domain/user/enums/OauthProvider.java
@@ -1,9 +1,11 @@
 package com.dearjolly.server.domain.user.enums;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Schema(description = "로그인 수단. 유저는 (provider + provider 회원 식별자) 로 구분한다")
 @Getter
 @RequiredArgsConstructor
 public enum OauthProvider {

--- a/src/main/java/com/dearjolly/server/domain/user/enums/OauthProvider.java
+++ b/src/main/java/com/dearjolly/server/domain/user/enums/OauthProvider.java
@@ -1,5 +1,6 @@
 package com.dearjolly.server.domain.user.enums;
 
+import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,4 +11,11 @@ public enum OauthProvider {
     APPLE("애플 로그인");
 
     private final String description;
+
+    public static OauthProvider from(String value) {
+        return Arrays.stream(values())
+                .filter(provider -> provider.name().equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 로그인 수단이다: " + value));
+    }
 }

--- a/src/main/java/com/dearjolly/server/domain/user/enums/OauthProvider.java
+++ b/src/main/java/com/dearjolly/server/domain/user/enums/OauthProvider.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@Schema(description = "로그인 수단. 유저는 (provider + provider 회원 식별자) 로 구분한다")
+@Schema(description = "로그인 수단")
 @Getter
 @RequiredArgsConstructor
 public enum OauthProvider {

--- a/src/main/java/com/dearjolly/server/domain/user/enums/TermsType.java
+++ b/src/main/java/com/dearjolly/server/domain/user/enums/TermsType.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@Schema(description = "약관 종류. SERVICE · PRIVACY 는 필수 동의, MARKETING 은 선택 동의다")
+@Schema(description = "약관 종류. SERVICE · PRIVACY 는 필수, MARKETING 은 선택이다")
 @Getter
 @RequiredArgsConstructor
 public enum TermsType {

--- a/src/main/java/com/dearjolly/server/domain/user/enums/TermsType.java
+++ b/src/main/java/com/dearjolly/server/domain/user/enums/TermsType.java
@@ -1,8 +1,10 @@
 package com.dearjolly.server.domain.user.enums;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Schema(description = "약관 종류. SERVICE · PRIVACY 는 필수 동의, MARKETING 은 선택 동의다")
 @Getter
 @RequiredArgsConstructor
 public enum TermsType {

--- a/src/main/java/com/dearjolly/server/global/auth/oauth/AppleOauthClient.java
+++ b/src/main/java/com/dearjolly/server/global/auth/oauth/AppleOauthClient.java
@@ -17,6 +17,7 @@ import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import java.io.IOException;
 import java.net.URLEncoder;
 import java.security.KeyFactory;
 import java.security.interfaces.ECPrivateKey;
@@ -33,6 +34,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
@@ -168,9 +170,11 @@ public class AppleOauthClient implements OauthClient {
                     .body(toQueryString(form))
                     .retrieve()
                     .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+                        log.warn("애플 토큰 요청이 거절됐다. status={}, body={}", res.getStatusCode(), readBody(res));
                         throw new BusinessException(ErrorCode.OAUTH_AUTHENTICATION_FAILED);
                     })
                     .onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
+                        log.warn("애플 토큰 요청 중 애플 서버 오류. status={}, body={}", res.getStatusCode(), readBody(res));
                         throw new BusinessException(ErrorCode.OAUTH_SERVER_ERROR);
                     })
                     .body(AppleTokenResponse.class);
@@ -181,6 +185,8 @@ public class AppleOauthClient implements OauthClient {
         } catch (RestClientException e) {
             throw new BusinessException(ErrorCode.OAUTH_SERVER_ERROR);
         } catch (Exception e) {
+            log.warn("애플 client_secret 생성에 실패했다. private key · key id · team id 조합을 확인한다. keyId={}, teamId={}",
+                    properties.keyId(), properties.teamId(), e);
             throw new BusinessException(ErrorCode.OAUTH_AUTHENTICATION_FAILED);
         }
     }
@@ -229,6 +235,10 @@ public class AppleOauthClient implements OauthClient {
         );
         jwt.sign(new ECDSASigner(privateKey));
         return jwt.serialize();
+    }
+
+    private String readBody(ClientHttpResponse response) throws IOException {
+        return new String(response.getBody().readAllBytes(), UTF_8);
     }
 
     private String toQueryString(Map<String, String> params) {

--- a/src/main/java/com/dearjolly/server/global/auth/oauth/KakaoOauthClient.java
+++ b/src/main/java/com/dearjolly/server/global/auth/oauth/KakaoOauthClient.java
@@ -7,6 +7,7 @@ import com.dearjolly.server.domain.user.enums.OauthProvider;
 import com.dearjolly.server.global.exception.exception.BusinessException;
 import com.dearjolly.server.global.exception.response.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -15,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
@@ -101,9 +103,11 @@ public class KakaoOauthClient implements OauthClient {
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                     .retrieve()
                     .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+                        log.warn("카카오 사용자 조회가 거절됐다. status={}, body={}", res.getStatusCode(), readBody(res));
                         throw new BusinessException(ErrorCode.OAUTH_AUTHENTICATION_FAILED);
                     })
                     .onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
+                        log.warn("카카오 사용자 조회 중 카카오 서버 오류. status={}, body={}", res.getStatusCode(), readBody(res));
                         throw new BusinessException(ErrorCode.OAUTH_SERVER_ERROR);
                     })
                     .body(KakaoUserResponse.class);
@@ -127,9 +131,11 @@ public class KakaoOauthClient implements OauthClient {
                     .body(toQueryString(form))
                     .retrieve()
                     .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+                        log.warn("카카오 인증 요청이 거절됐다. uri={}, status={}, body={}", uri, res.getStatusCode(), readBody(res));
                         throw new BusinessException(ErrorCode.OAUTH_AUTHENTICATION_FAILED);
                     })
                     .onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
+                        log.warn("카카오 서버 오류. uri={}, status={}, body={}", uri, res.getStatusCode(), readBody(res));
                         throw new BusinessException(ErrorCode.OAUTH_SERVER_ERROR);
                     })
                     .body(responseType);
@@ -138,6 +144,10 @@ public class KakaoOauthClient implements OauthClient {
         } catch (RestClientException e) {
             throw new BusinessException(ErrorCode.OAUTH_SERVER_ERROR);
         }
+    }
+
+    private String readBody(ClientHttpResponse response) throws IOException {
+        return new String(response.getBody().readAllBytes(), UTF_8);
     }
 
     private String toQueryString(Map<String, String> params) {

--- a/src/main/java/com/dearjolly/server/global/auth/oauth/OauthProviderConverter.java
+++ b/src/main/java/com/dearjolly/server/global/auth/oauth/OauthProviderConverter.java
@@ -1,0 +1,11 @@
+package com.dearjolly.server.global.auth.oauth;
+
+import com.dearjolly.server.domain.user.enums.OauthProvider;
+import org.springframework.core.convert.converter.Converter;
+
+public class OauthProviderConverter implements Converter<String, OauthProvider> {
+    @Override
+    public OauthProvider convert(String source) {
+        return OauthProvider.from(source);
+    }
+}

--- a/src/main/java/com/dearjolly/server/global/config/OpenApiConfig.java
+++ b/src/main/java/com/dearjolly/server/global/config/OpenApiConfig.java
@@ -18,15 +18,10 @@ public class OpenApiConfig {
     private static final String DESCRIPTION = """
             Dear Jolly 앱과 서버 사이의 계약 문서다.
 
-            ### 공통 규약
             - 인증: `Authorization: Bearer {accessToken}` (액세스 30분 / 리프레시 14일)
-            - Content-Type: `application/json; charset=UTF-8`
             - 날짜 `yyyy-MM-dd` · 날짜+시각 `yyyy-MM-dd'T'HH:mm:ss`
-            - 성공 응답은 래퍼 없이 DTO 를 그대로 내려준다. 조회·수정 `200`, 생성 `201`, 본문 없음 `204`.
-            - 실패 응답은 모든 API 가 `{ status, code, message }` 형태로 같다. `message` 는 유저에게 그대로 보여줘도 된다.
-
-            ### 온보딩 가드
-            필수 약관 2종 동의 + 닉네임 등록을 마쳐야 편지 · 홈 API 를 호출할 수 있다. 미완료면 `USER_005` 다.
+            - 성공 응답은 래퍼 없이 DTO 를 그대로 내려준다. 실패 응답은 모두 `{ status, code, message }` 형태이며 `message` 는 유저에게 그대로 보여줘도 된다.
+            - 온보딩(필수 약관 2종 동의 + 닉네임 등록)을 마쳐야 편지 · 홈 API 를 호출할 수 있다. 미완료면 `USER_005` 다.
 
             ### 모든 API 공통 에러
             | code | status | message |

--- a/src/main/java/com/dearjolly/server/global/config/OpenApiConfig.java
+++ b/src/main/java/com/dearjolly/server/global/config/OpenApiConfig.java
@@ -1,0 +1,107 @@
+package com.dearjolly.server.global.config;
+
+import com.dearjolly.server.global.auth.principal.LoginUser;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springdoc.core.utils.SpringDocUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    public static final String BEARER_SCHEME = "bearerAuth";
+
+    private static final String DESCRIPTION = """
+            Dear Jolly 앱과 서버 사이의 계약 문서다.
+
+            ### 공통 규약
+            - 인증: `Authorization: Bearer {accessToken}` (액세스 30분 / 리프레시 14일)
+            - Content-Type: `application/json; charset=UTF-8`
+            - 날짜 `yyyy-MM-dd` · 날짜+시각 `yyyy-MM-dd'T'HH:mm:ss`
+            - 성공 응답은 래퍼 없이 DTO 를 그대로 내려준다. 조회·수정 `200`, 생성 `201`, 본문 없음 `204`.
+            - 실패 응답은 모든 API 가 `{ status, code, message }` 형태로 같다. `message` 는 유저에게 그대로 보여줘도 된다.
+
+            ### 온보딩 가드
+            필수 약관 2종 동의 + 닉네임 등록을 마쳐야 편지 · 홈 API 를 호출할 수 있다. 미완료면 `USER_005` 다.
+
+            ### 모든 API 공통 에러
+            | code | status | message |
+            | --- | --- | --- |
+            | `COMMON_001` | 400 | 잘못된 요청입니다. |
+            | `COMMON_002` | 404 | 요청하신 경로를 찾을 수 없습니다. |
+            | `COMMON_003` | 405 | 지원하지 않는 요청 방식입니다. |
+            | `COMMON_004` | 429 | 요청이 너무 많습니다. 잠시 후 다시 시도해주세요. |
+            | `COMMON_005` | 500 | 일시적인 오류가 발생했습니다. |
+
+            ### 인증이 필요한 API 공통 에러
+            | code | status | message |
+            | --- | --- | --- |
+            | `AUTH_005` | 401 | 유효하지 않은 토큰입니다. |
+            | `AUTH_006` | 403 | 접근 권한이 없습니다. |
+            | `AUTH_007` | 401 | 탈퇴한 계정입니다. 다시 로그인해주세요. |
+            """;
+
+    static {
+        // @LoginUser 는 토큰에서 유저를 꺼내는 서버 내부 파라미터다. 등록하지 않으면
+        // springdoc 이 평범한 Long 파라미터로 보고 userId 를 쿼리 파라미터로 문서에 노출한다.
+        SpringDocUtils.getConfig().addAnnotationsToIgnore(LoginUser.class);
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Dear Jolly API")
+                        .version("v1")
+                        .description(DESCRIPTION))
+                .components(new Components().addSecuritySchemes(BEARER_SCHEME, bearerScheme()))
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_SCHEME));
+    }
+
+    @Bean
+    public GroupedOpenApi allApi() {
+        return group("all", "전체", "/api/v1/**");
+    }
+
+    @Bean
+    public GroupedOpenApi authApi() {
+        return group("auth", "인증", "/api/v1/auth/**");
+    }
+
+    @Bean
+    public GroupedOpenApi userApi() {
+        return group("user", "사용자", "/api/v1/users/**");
+    }
+
+    @Bean
+    public GroupedOpenApi letterApi() {
+        return group("letter", "편지 · 홈", "/api/v1/letters/**", "/api/v1/home");
+    }
+
+    @Bean
+    public GroupedOpenApi versionApi() {
+        return group("version", "버전", "/api/v1/version");
+    }
+
+    private GroupedOpenApi group(String name, String displayName, String... paths) {
+        return GroupedOpenApi.builder()
+                .group(name)
+                .displayName(displayName)
+                .pathsToMatch(paths)
+                .build();
+    }
+
+    private SecurityScheme bearerScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization")
+                .description("소셜 로그인 딥링크로 받은 accessToken 을 그대로 넣는다. `Bearer` 는 붙이지 않는다.");
+    }
+}

--- a/src/main/java/com/dearjolly/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/dearjolly/server/global/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
             "/api/v1/version",
             "/actuator/health",
             "/error",
+            "/swagger-ui.html",
             "/swagger-ui/**",
             "/v3/api-docs/**"
     };
@@ -40,6 +41,7 @@ public class SecurityConfig {
             "/api/v1/version",
             "/actuator/**",
             "/error",
+            "/swagger-ui.html",
             "/swagger-ui/**",
             "/v3/api-docs/**"
     );

--- a/src/main/java/com/dearjolly/server/global/config/WebConfig.java
+++ b/src/main/java/com/dearjolly/server/global/config/WebConfig.java
@@ -1,10 +1,12 @@
 package com.dearjolly.server.global.config;
 
 import com.dearjolly.server.global.auth.interceptor.OnboardingInterceptor;
+import com.dearjolly.server.global.auth.oauth.OauthProviderConverter;
 import com.dearjolly.server.global.auth.principal.LoginUserArgumentResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -30,5 +32,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginUserArgumentResolver);
+    }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new OauthProviderConverter());
     }
 }

--- a/src/main/java/com/dearjolly/server/global/exception/response/ErrorResponse.java
+++ b/src/main/java/com/dearjolly/server/global/exception/response/ErrorResponse.java
@@ -1,14 +1,21 @@
 package com.dearjolly.server.global.exception.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.ResponseEntity;
 
+@Schema(description = "모든 API 가 공유하는 실패 응답")
 @Builder
 @Getter
 public class ErrorResponse {
+    @Schema(description = "HTTP 상태 코드", example = "400")
     private final int status;
+
+    @Schema(description = "{도메인}_{일련번호} 형식의 에러 코드", example = "COMMON_001")
     private final String code;
+
+    @Schema(description = "유저에게 그대로 보여줘도 되는 문구", example = "잘못된 요청입니다.")
     private final String message;
 
     public static ResponseEntity<ErrorResponse> toResponseEntity(ErrorCode errorCode) {

--- a/src/main/java/com/dearjolly/server/global/version/controller/VersionController.java
+++ b/src/main/java/com/dearjolly/server/global/version/controller/VersionController.java
@@ -21,10 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "버전", description = """
-        최소 지원 버전 및 정책 URL 조회 API.
-
-        **로그인 전에도 호출할 수 있다.** 공지사항 · 개인정보처리방침 · 이용약관은 별도 API 가 없고, 이 응답의 링크를 웹뷰로 연다.""")
+@Tag(name = "버전", description = "최소 지원 버전 및 정책 URL 조회 API. 로그인 전에도 호출할 수 있다.")
 @RestController
 @RequestMapping("/api/v1/version")
 @RequiredArgsConstructor
@@ -34,15 +31,9 @@ public class VersionController {
     @Operation(
             summary = "최소 지원 버전 조회",
             description = """
-                    앱 최소 지원 버전과 정책 페이지 URL 을 조회한다.
-
-                    - 앱 버전이 `minSupportedVersion` 미만이면 강제 업데이트를 유도한다.
-                      **판정은 앱이 한다.** 서버는 앱 버전을 받지 않는다.
-                    - `forceUpdate` 는 참고용 보조 신호다. 앱은 자기 버전과 `minSupportedVersion` 을 직접 비교한다.
+                    - 강제 업데이트 **판정은 앱이 한다.** 서버는 앱 버전을 받지 않으며, `forceUpdate` 는 보조 신호다.
                     - **공지사항 · 개인정보처리방침 · 이용약관은 별도 API 가 없다.** 이 응답의 링크를 웹뷰로 연다.
-                    - 설정 화면 하단의 `현재 버전` 표기는 앱 로컬 값이며 이 응답과 무관하다.
-                    - `platform` 을 생략하면 공통 값을 반환하고, 값을 주면 **그 플랫폼에 설정된 값만** 공통 값을 덮어쓴다.
-                    - `platform` 이 `IOS` · `AOS` 가 아니면 `COMMON_001` 이다.""")
+                    - `platform` 을 생략하면 공통 값을, 주면 그 플랫폼에 설정된 값만 덮어쓴 결과를 반환한다.""")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(

--- a/src/main/java/com/dearjolly/server/global/version/controller/VersionController.java
+++ b/src/main/java/com/dearjolly/server/global/version/controller/VersionController.java
@@ -2,11 +2,17 @@ package com.dearjolly.server.global.version.controller;
 
 import static org.springframework.http.HttpStatus.OK;
 
+import com.dearjolly.server.global.exception.response.ErrorResponse;
 import com.dearjolly.server.global.version.VersionProperties;
 import com.dearjolly.server.global.version.dto.VersionGetResponse;
 import com.dearjolly.server.global.version.enums.Platform;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +21,36 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "버전", description = "최소 지원 버전 및 정책 URL 조회 API")
+@Tag(name = "버전", description = """
+        최소 지원 버전 및 정책 URL 조회 API.
+
+        **로그인 전에도 호출할 수 있다.** 공지사항 · 개인정보처리방침 · 이용약관은 별도 API 가 없고, 이 응답의 링크를 웹뷰로 연다.""")
 @RestController
 @RequestMapping("/api/v1/version")
 @RequiredArgsConstructor
 public class VersionController {
     private final VersionProperties versionProperties;
 
-    @Operation(summary = "최소 지원 버전 조회")
+    @Operation(
+            summary = "최소 지원 버전 조회",
+            description = """
+                    앱 최소 지원 버전과 정책 페이지 URL 을 조회한다.
+
+                    - 앱 버전이 `minSupportedVersion` 미만이면 강제 업데이트를 유도한다.
+                      **판정은 앱이 한다.** 서버는 앱 버전을 받지 않는다.
+                    - `forceUpdate` 는 참고용 보조 신호다. 앱은 자기 버전과 `minSupportedVersion` 을 직접 비교한다.
+                    - **공지사항 · 개인정보처리방침 · 이용약관은 별도 API 가 없다.** 이 응답의 링크를 웹뷰로 연다.
+                    - 설정 화면 하단의 `현재 버전` 표기는 앱 로컬 값이며 이 응답과 무관하다.
+                    - `platform` 을 생략하면 공통 값을 반환하고, 값을 주면 **그 플랫폼에 설정된 값만** 공통 값을 덮어쓴다.
+                    - `platform` 이 `IOS` · `AOS` 가 아니면 `COMMON_001` 이다.""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "`COMMON_001` 정의되지 않은 platform",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @SecurityRequirements
     @GetMapping
     public ResponseEntity<VersionGetResponse> getVersion(
             @Parameter(description = "플랫폼 (IOS, AOS). 생략하면 공통 값을 반환한다")

--- a/src/main/java/com/dearjolly/server/global/version/dto/VersionGetResponse.java
+++ b/src/main/java/com/dearjolly/server/global/version/dto/VersionGetResponse.java
@@ -2,14 +2,32 @@ package com.dearjolly.server.global.version.dto;
 
 import com.dearjolly.server.global.version.VersionProperties;
 import com.dearjolly.server.global.version.enums.Platform;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-/** @param forceUpdate latest 와 minSupported 가 같다는 것은 그 아래 버전을 더 받아주지 않겠다는 뜻이다. 앱은 자기 버전과 minSupportedVersion 을 직접 비교하고, 이 값은 보조 신호로 쓴다. / */
+@Schema(description = "앱 최소 지원 버전과 정책 페이지 URL")
 public record VersionGetResponse(
+
+        @Schema(description = "최신 배포 버전", example = "1.0.0", requiredMode = Schema.RequiredMode.REQUIRED)
         String latestVersion,
+
+        @Schema(description = "이 버전 미만이면 강제 업데이트. 판정은 앱이 한다", example = "1.0.0",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         String minSupportedVersion,
+
+        @Schema(
+                description = "강제 업데이트 여부. latest 와 minSupported 가 같다는 것은 그 아래 버전을 더 받아주지 않겠다는 뜻이며, "
+                        + "앱은 자기 버전과 minSupportedVersion 을 직접 비교하고 이 값은 보조 신호로 쓴다",
+                example = "false",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         boolean forceUpdate,
+
+        @Schema(description = "개인정보처리방침 URL", example = "https://dearjolly.com/privacy")
         String privacyPolicyUrl,
+
+        @Schema(description = "서비스 이용약관 URL", example = "https://dearjolly.com/terms")
         String termsOfServiceUrl,
+
+        @Schema(description = "공지사항 URL", example = "https://dearjolly.com/notice")
         String noticeUrl
 ) {
     public static VersionGetResponse of(VersionProperties properties, Platform platform) {

--- a/src/main/java/com/dearjolly/server/global/version/dto/VersionGetResponse.java
+++ b/src/main/java/com/dearjolly/server/global/version/dto/VersionGetResponse.java
@@ -14,9 +14,7 @@ public record VersionGetResponse(
                 requiredMode = Schema.RequiredMode.REQUIRED)
         String minSupportedVersion,
 
-        @Schema(
-                description = "강제 업데이트 여부. latest 와 minSupported 가 같다는 것은 그 아래 버전을 더 받아주지 않겠다는 뜻이며, "
-                        + "앱은 자기 버전과 minSupportedVersion 을 직접 비교하고 이 값은 보조 신호로 쓴다",
+        @Schema(description = "강제 업데이트 여부. 앱은 자기 버전과 minSupportedVersion 을 직접 비교하고 이 값은 보조 신호로 쓴다",
                 example = "false",
                 requiredMode = Schema.RequiredMode.REQUIRED)
         boolean forceUpdate,

--- a/src/main/java/com/dearjolly/server/global/version/enums/Platform.java
+++ b/src/main/java/com/dearjolly/server/global/version/enums/Platform.java
@@ -1,8 +1,10 @@
 package com.dearjolly.server.global.version.enums;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Schema(description = "버전 조회 대상 플랫폼")
 @Getter
 @RequiredArgsConstructor
 public enum Platform {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -50,6 +50,12 @@ management:
     health:
       show-details: never
 
+# Swagger UI 는 그룹 목록의 첫 문서를 먼저 띄운다. 지정하지 않으면 도메인 그룹 하나가 열려
+# 전체 API 를 보려면 매번 드롭다운을 만져야 한다.
+springdoc:
+  swagger-ui:
+    urls-primary-name: 전체
+
 # ===== MinIO (우표 이미지 저장소) =====
 minio:
   endpoint: ${MINIO_ENDPOINT:http://localhost:9000}       # 서버 → MinIO 내부 호출용

--- a/src/test/java/com/dearjolly/server/domain/user/controller/AuthApiTest.java
+++ b/src/test/java/com/dearjolly/server/domain/user/controller/AuthApiTest.java
@@ -12,6 +12,8 @@ import io.restassured.http.ContentType;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
@@ -36,6 +38,17 @@ class AuthApiTest extends ApiTestSupport {
                 .statusCode(HttpStatus.FOUND.value())
                 .header(HttpHeaders.LOCATION, containsString("appleid.apple.com/auth/authorize"))
                 .header(HttpHeaders.LOCATION, containsString("response_mode=form_post"));
+    }
+
+    @DisplayName("GET /api/v1/auth/{provider} : provider 는 대소문자를 가리지 않는다")
+    @ValueSource(strings = {"kakao", "Kakao", "kAkAo"})
+    @ParameterizedTest
+    void authorizeIgnoresProviderCase(String provider) {
+        given().redirects().follow(false)
+                .when().get("/api/v1/auth/" + provider)
+                .then()
+                .statusCode(HttpStatus.FOUND.value())
+                .header(HttpHeaders.LOCATION, containsString("kauth.kakao.com/oauth/authorize"));
     }
 
     @DisplayName("GET /api/v1/auth/{provider} : 지원하지 않는 provider 면 COMMON_001")

--- a/src/test/java/com/dearjolly/server/global/config/OpenApiDocsTest.java
+++ b/src/test/java/com/dearjolly/server/global/config/OpenApiDocsTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -86,6 +87,18 @@ class OpenApiDocsTest extends ApiTestSupport {
                         contains("SUBMITTED", "FEEDBACK_IN_PROGRESS", "FEEDBACK_COMPLETED"))
                 .body("components.schemas.LetterSummaryResponse.properties.status.enum",
                         contains("SUBMITTED", "FEEDBACK_IN_PROGRESS", "FEEDBACK_COMPLETED"));
+    }
+
+    @DisplayName("GET /v3/api-docs/swagger-config : 그룹 선택 없이 열면 전체 문서가 뜬다")
+    @Test
+    void primaryGroupIsAll() {
+        given()
+                .when().get("/v3/api-docs/swagger-config")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("urls.name", hasItem("전체"))
+                .body("urls.find { it.name == '전체' }.url", equalTo("/v3/api-docs/all"))
+                .body("'urls.primaryName'", equalTo("전체"));
     }
 
     @DisplayName("GET /swagger-ui/index.html : Swagger UI 가 인증 없이 열린다")

--- a/src/test/java/com/dearjolly/server/global/config/OpenApiDocsTest.java
+++ b/src/test/java/com/dearjolly/server/global/config/OpenApiDocsTest.java
@@ -1,0 +1,100 @@
+package com.dearjolly.server.global.config;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.dearjolly.server.support.ApiTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpStatus;
+
+class OpenApiDocsTest extends ApiTestSupport {
+    @DisplayName("GET /v3/api-docs : 인증 없이 열리고 모든 엔드포인트가 실린다")
+    @Test
+    void apiDocs() {
+        given()
+                .when().get("/v3/api-docs")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("info.title", equalTo("Dear Jolly API"))
+                .body("paths", hasKey("/api/v1/auth/{provider}"))
+                .body("paths", hasKey("/api/v1/auth/kakao/callback"))
+                .body("paths", hasKey("/api/v1/auth/apple/callback"))
+                .body("paths", hasKey("/api/v1/auth/reissue"))
+                .body("paths", hasKey("/api/v1/auth/logout"))
+                .body("paths", hasKey("/api/v1/users"))
+                .body("paths", hasKey("/api/v1/users/terms"))
+                .body("paths", hasKey("/api/v1/users/nickname"))
+                .body("paths", hasKey("/api/v1/letters"))
+                .body("paths", hasKey("/api/v1/letters/{letterId}"))
+                .body("paths", hasKey("/api/v1/home"))
+                .body("paths", hasKey("/api/v1/version"))
+                .body("components.securitySchemes.bearerAuth.scheme", equalTo("bearer"));
+    }
+
+    @DisplayName("GET /v3/api-docs : 도메인별 그룹 문서가 각각 열린다")
+    @ValueSource(strings = {"all", "auth", "user", "letter", "version"})
+    @ParameterizedTest
+    void groupedApiDocs(String group) {
+        given()
+                .when().get("/v3/api-docs/" + group)
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("paths", notNullValue());
+    }
+
+    @DisplayName("GET /v3/api-docs : @LoginUser 는 쿼리 파라미터로 노출되지 않는다")
+    @Test
+    void loginUserIsNotExposedAsParameter() {
+        given()
+                .when().get("/v3/api-docs")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("paths.'/api/v1/home'.get", not(hasKey("parameters")));
+    }
+
+    @DisplayName("GET /v3/api-docs : 인증이 필요 없는 API 만 security 가 비어 있다")
+    @Test
+    void publicApiHasNoSecurity() {
+        given()
+                .when().get("/v3/api-docs")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("security[0]", hasKey("bearerAuth"))
+                .body("paths.'/api/v1/version'.get.security", empty())
+                .body("paths.'/api/v1/auth/{provider}'.get.security", empty())
+                .body("paths.'/api/v1/auth/reissue'.post.security", empty())
+                .body("paths.'/api/v1/auth/logout'.post", not(hasKey("security")));
+    }
+
+    @DisplayName("GET /v3/api-docs : 편지 상태에 내부 전용 FEEDBACK_FAILED 는 실리지 않는다")
+    @Test
+    void internalStatusIsNotDocumented() {
+        given()
+                .when().get("/v3/api-docs")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("components.schemas.LetterGetResponse.properties.status.enum",
+                        contains("SUBMITTED", "FEEDBACK_IN_PROGRESS", "FEEDBACK_COMPLETED"))
+                .body("components.schemas.LetterSummaryResponse.properties.status.enum",
+                        contains("SUBMITTED", "FEEDBACK_IN_PROGRESS", "FEEDBACK_COMPLETED"));
+    }
+
+    @DisplayName("GET /swagger-ui/index.html : Swagger UI 가 인증 없이 열린다")
+    @Test
+    void swaggerUi() {
+        given()
+                .when().get("/swagger-ui/index.html")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body(containsString("swagger-ui"));
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -53,3 +53,7 @@ dearjolly:
       key-id: TESTKEYID
       private-key: ""
       redirect-uri: http://localhost:8080/api/v1/auth/apple/callback
+
+springdoc:
+  swagger-ui:
+    urls-primary-name: 전체


### PR DESCRIPTION
## 📣 Related Issue
- close #

## 📝 Key Changes
- 소셜 로그인 `provider` 를 대소문자 구분 없이 받도록 변경 (`/api/v1/auth/kakao` · `/Kakao` · `/KAKAO` 모두 동작)
- `docs/API명세.md` 내용을 Swagger 문서에 반영: API 별 설명·성공/실패 응답 코드, 에러 코드별 응답 예시, DTO·enum 스키마
- Swagger 를 전체 · 인증 · 사용자 · 편지·홈 · 버전 그룹으로 분리하고 기본 문서를 `전체` 로 지정
- Swagger 관련 오류 수정: `@LoginUser` 가 `userId` 쿼리 파라미터로 노출되던 것, `/swagger-ui.html` 이 인증에 막히던 것, 내부 전용 상태값 `FEEDBACK_FAILED` 가 응답 스키마에 실리던 것
- 소셜 로그인 실패 시 provider 응답 본문을 로그로 남기도록 변경

## To Reviewers
- merge 되면 `main` push 로 EC2 배포가 실행된다.
- API 동작 변경은 `provider` 대소문자 허용 한 건이다. 기존 대문자 호출은 그대로 동작하고, 지원하지 않는 값은 이전과 같이 `COMMON_001` 이다.
- 나머지는 문서용 어노테이션과 설정 변경이며, 문서 생성 자체는 `OpenApiDocsTest` 로 검증한다.
