### PR TITLE
[CHORE] 소셜 로그인 콘솔 설정 문서 추가 및 JPA_DDL_AUTO 고정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,9 +59,5 @@ out/
 !.env.local.example
 !.env.prod.example
 
-## 소셜 로그인 콘솔 설정 런북 ##
-# 실제 식별자·운영 주소가 들어 있어 추적하지 않는다.
-docs/*회원가입.md
-
 ## 남은 것 메모 ##
 docs/남은것.md

--- a/docs/애플회원가입.md
+++ b/docs/애플회원가입.md
@@ -1,0 +1,111 @@
+애플
+
+전제: Apple Developer Program 유료 멤버십(연 $99)이 필요하다.
+
+애플 로그인은 **운영 환경에서만 동작시킨다.** Apple 은 Return URL 로 localhost 를 받지 않아
+로컬에서는 설정 자체가 불가능하다. 카카오와 달리 우회 방법이 없다.
+
+  운영 주소 : https://{SITE_ADDRESS}   ({SITE_ADDRESS} 는 infra/env/.env.prod 의 값)
+  설정 파일 : infra/env/.env.prod      (커밋되지 않는 파일)
+
+아래에서 {SITE_ADDRESS} 와 <...> 로 표기한 곳은 실제 값으로 바꿔 읽는다.
+실제 값은 전부 infra/env/.env.prod 에 있고 이 문서에는 적지 않는다.
+
+※ sslip.io 는 IP 를 도메인으로 매핑해 주는 서비스라 Apple 이 도메인으로 인정한다.
+   EC2 퍼블릭 IP 를 그대로 넣으면 "One or more domains are invalid." 로 거부된다.
+※ 인증서는 Caddy 가 Let's Encrypt 로 자동 발급한다 (infra/caddy/Caddyfile.prod.template).
+   Apple 은 TLS 1.2 이상을 요구하는데 이 구성이면 충족한다.
+
+### 1. Team ID 확인
+[developer.apple.com/account](https://developer.apple.com/account) → [멤버십 세부사항] → Team ID (10자 영숫자) 확인 → `APPLE_TEAM_ID` 에 넣기
+
+   → 이 프로젝트의 값은 infra/env/.env.prod 의 APPLE_TEAM_ID 에 있다.
+
+### 2. App ID 생성
+[Certificates, Identifiers & Profiles] → [Identifiers(식별자)] → [+] → [App IDs] → [App] → [Description] 입력 (DearJolly) → [Bundle ID] explicit 입력 (com.dearjolly.app) → [Capabilities] 에서 [Sign in with Apple] 체크 → [Continue] → [Register]
+
+※ Wildcard 로는 Sign in with Apple 을 켤 수 없다. 반드시 Explicit 이어야 한다.
+※ 이건 iOS 앱용 식별자다. 서버가 쓰는 값이 아니며, 3번 Services ID 의 Primary App ID 로만 지정된다.
+※ 실제 iOS 앱의 Bundle Identifier 와 같아야 한다.
+
+### 3. Services ID 생성 — APPLE_CLIENT_ID
+[Identifiers] → [+] → [Services IDs] → [Continue]
+   → [Description] 입력 (DearJolly Auth)
+   → [Identifier] 입력 (com.dearjolly.auth) - 이 값이 APPLE_CLIENT_ID
+   → [Continue] → [Register]
+
+※ App ID(com.dearjolly.app) 와 같은 값을 쓸 수 없다. Apple 식별자는 종류를 막론하고 전역 유일하다.
+※ 서버가 id_token 의 aud 를 이 값과 대조하므로 .env 의 APPLE_CLIENT_ID 와 글자 하나까지 같아야 한다.
+   다르면 AUTH_002 가 난다.
+※ 등록 후 변경 불가. 바꾸려면 삭제하고 새로 만들어야 한다.
+
+### 4. Services ID 설정
+[Identifiers] → 방금 만든 Services ID 클릭 → [Sign in with Apple] 체크 → [Configure] → [Primary App ID] 2번에서 만든 App ID 선택
+→ [Register Website URLs] 영역
+→ [Domains and Subdomains] "{SITE_ADDRESS}" 입력
+→ [Return URLs] "https://{SITE_ADDRESS}/api/v1/auth/apple/callback" 입력
+→ [Done] → [Continue] → [Save]
+
+※ Domains 칸은 스킴(https://) 없이 호스트만, Return URLs 는 https:// 포함 전체 URL 을 넣는다.
+※ Return URL 은 /callback 까지 붙여야 하고 끝에 슬래시를 붙이면 안 된다.
+   서버가 토큰 교환 시 이 값을 그대로 redirect_uri 로 보내므로 한 글자만 달라도 실패한다.
+※ localhost 나 IP 는 "One or more domains are invalid." 로 거부된다.
+※ 개인 계정은 최대 10개, 조직 계정은 최대 100개까지 등록 가능하다.
+   도메인을 바꾸면 여기에 한 줄 추가하고 .env.prod 의 APPLE_REDIRECT_URI 도 함께 고친다.
+
+### 5. Key 발급 — APPLE_KEY_ID 와 APPLE_PRIVATE_KEY
+[Keys] → [+] → Key Name 입력 → [Sign in with Apple] 체크 → [Configure]
+   → Primary App ID: 2번의 App ID 선택 → Save → Continue → Register
+   → Key ID 표시됨              → APPLE_KEY_ID 에 넣기
+   → [Download] 로 AuthKey_XXXXXXXXXX.p8 내려받기
+
+※ .p8 은 딱 한 번만 다운로드된다. 잃어버리면 Revoke 후 재발급해야 한다.
+
+### 6. .p8 을 한 줄로 만들어 넣기
+tr -d '\n' < ~/Downloads/AuthKey_XXXXXXXXXX.p8
+
+출력 전체를 APPLE_PRIVATE_KEY 에 그대로 붙여넣는다.
+서버가 BEGIN/END 줄과 공백을 제거하므로 PEM 전체든 base64 본문만이든 동작한다.
+(AppleOauthClient.createClientSecret 참고)
+
+### 7. .env.prod 에 값 넣기
+infra/env/.env.prod (커밋되지 않는 파일)
+
+  APPLE_CLIENT_ID=com.dearjolly.auth        # Services ID (Bundle ID 아님)
+  APPLE_TEAM_ID=<1번의 Team ID>
+  APPLE_KEY_ID=<5번의 Key ID>
+  APPLE_PRIVATE_KEY=<6번 출력 한 줄>
+  APPLE_REDIRECT_URI=https://{SITE_ADDRESS}/api/v1/auth/apple/callback
+
+※ infra/env/.env.local (로컬) 의 애플 값은 비워 둔다. 로컬에서는 카카오만 쓴다.
+※ 배포는 scripts-local/github-secrets.sh 로 .env.prod 를 Secrets 에 올린 뒤 진행한다.
+
+### 8. 확인
+배포 후 운영 서버에서:
+
+curl -is https://{SITE_ADDRESS}/api/v1/auth/APPLE | grep -i location
+
+  → client_id 가 Services ID(com.dearjolly.auth) 인지
+  → redirect_uri 가 4번에 등록한 Return URL 과 완전히 같은지
+  → response_mode=form_post 가 붙어 있는지
+
+그 Location URL 을 브라우저에서 열어 Apple ID 로 로그인하면
+dearjolly://auth/callback?accessToken=... 로 리다이렉트된다.
+앱이 없으면 브라우저가 열지 못하지만, 주소창에 토큰이 보이면 성공이다.
+
+참고: 왜 애플만 콜백이 POST 인가
+scope=name email 을 요청하면 Apple 이 response_mode=form_post 를 강제한다.
+그래서 콜백을 POST /api/v1/auth/apple/callback 으로 받고, code 와 함께 오는
+id_token 에서 sub(회원 식별자) 와 email 을 꺼낸다.
+카카오처럼 별도 유저 정보 API 를 호출하지 않는다.
+
+참고: 이메일
+Apple 은 사용자가 "이메일 가리기" 를 고르면 private relay 주소를 주고,
+아예 거부하면 email 클레임이 없다. USERS.email 은 NULL 허용이라 그대로 저장된다.
+또한 email 은 최초 로그인 1회만 내려오므로, 두 번째 로그인부터는 없을 수 있다.
+서버는 (oauth_provider, oauth_id) 로만 회원을 식별하므로 문제되지 않는다.
+
+참고: 탈퇴 시 연결 해제
+Apple 연동 해제는 App Store 심사 요건이다. 로그인할 때 받은 provider refresh token 을
+USERS.oauth_refresh_token 에 저장해 두고 탈퇴 시 revoke 에 쓰므로,
+앱이 인가 코드를 따로 넘길 필요가 없다 (기능명세 §3.1.3).

--- a/docs/카카오회원가입.md
+++ b/docs/카카오회원가입.md
@@ -1,0 +1,55 @@
+카카오
+
+1. 앱 생성
+developers.kakao.com → 카카오계정 로그인 → 앱 → 앱 생성 
+
+2. 카카오 로그인 활성화
+[제품 설정] 메뉴 → [카카오 로그인] → [일반] → [사용 설정] 상태 ON, [OpenID Connect] 상태 ON
+
+3. 키 확인
+[앱 설정] 메뉴 → [앱] → [플랫폼 키] → [REST API 키] → KAKAO_CLIENT_ID 에 넣기
+[앱 설정] 메뉴 → [앱] → [어드민 키] → KAKAO_ADMIN_KEY 에 넣기
+
+4. Redirect URI 등록  (※ https 다. Caddy 가 앞단에서 TLS 를 종단한다)
+[앱 설정] 메뉴 → [앱] → [플랫폼 키] → [REST API 키] 클릭 → [카카오 로그인 리다이렉트 URI] → "https://localhost:8080/api/v1/auth/kakao/callback" [등록]
+
+※ 배포 후에는 운영 주소를 한 줄 더 추가한다 (여러 개 등록 가능).
+
+5. 이메일 동의항목 — MVP 에서는 설정하지 않는다
+[제품 설정] 메뉴 → [카카오 로그인] → [동의항목] → [개인정보] 표에서
+[카카오계정(이메일)] 이 "권한 없음" 으로 보이면 정상이다. 설정 버튼이 없다.
+
+※ account_email 은 비즈니스 앱 전용 항목이라 일반 앱에서는 쓸 수 없다.
+※ 로그인은 카카오 id 만으로 동작하므로 이메일 없이 진행한다.
+   USERS.email 은 NULL 허용이고, 앱은 이메일이 없으면 provider 명만 표시한다 (기능명세 §3.1.4).
+※ 필요해지면 [앱 설정] → [비즈니스] 에서 비즈 앱 전환.
+   개인 개발자는 개인정보처리방침 URL 과 카카오 심사가 필요하다.
+※ 닉네임/프로필 이미지는 [사용 안 함] 그대로 둔다. 서버는 id 와 email 만 쓴다.
+
+6. .env.local 에 값 넣기
+infra/env/.env.local 을 열어 아래 두 줄을 채운다. (이 파일은 .gitignore 에 걸려 커밋되지 않는다)
+
+  KAKAO_CLIENT_ID=<REST API 키>
+  KAKAO_ADMIN_KEY=<어드민 키>
+  KAKAO_CLIENT_SECRET=          # [보안] 에서 활성화한 경우에만. 비우면 코드가 파라미터를 뺀다
+  KAKAO_REDIRECT_URI=https://localhost:8080/api/v1/auth/kakao/callback
+
+※ 어드민 키는 모든 사용자 연결 해제가 가능한 권한이다. 절대 클라이언트나 .example 파일에 넣지 않는다.
+※ KAKAO_ADMIN_KEY 가 비어 있어도 로그인은 되지만, 회원 탈퇴 시 unlink 를 건너뛰고 로그만 남는다.
+
+7. 확인
+./run.sh restart
+curl -is https://localhost:8080/api/v1/auth/KAKAO | grep -i location
+
+  → client_id 에 값이 채워져 있고
+  → redirect_uri 가 콘솔에 등록한 문자열과 완전히 같아야 한다 (끝 슬래시 하나만 달라도 KOE006)
+
+그 Location URL 을 브라우저에 붙여넣어 로그인하면
+dearjolly://auth/callback?accessToken=...&refreshToken=...&isNewUser=true 로 리다이렉트된다.
+앱이 없으면 브라우저가 열지 못하지만, 주소창에 토큰이 보이면 성공이다.
+
+DB 확인:
+docker exec dear-jolly-mysql mysql -ujolly -p<비밀번호> dearjolly \
+  -e "SELECT user_id, oauth_provider, oauth_id, email, nickname, status FROM users\G"
+
+※ email 이 NULL 인 것이 정상이다 (5번 참고).

--- a/infra/README.md
+++ b/infra/README.md
@@ -266,8 +266,8 @@ JVM 힙은 `compose.prod.yaml` 의 `JAVA_OPTS` 가 `MaxRAMPercentage=35` 로 묶
 
 | 변수 | 기본값 | 설명 |
 | --- | --- | --- |
-| `JPA_DDL_AUTO` | 앱 기본값 `validate` | `FLYWAY_ENABLED` 와 **항상 같이 움직인다** |
-| `FLYWAY_ENABLED` | `true` | |
+| `JPA_DDL_AUTO` | `validate` | 전 환경 고정. 스키마는 Flyway 가 소유한다 |
+| `FLYWAY_ENABLED` | `true` | 전 환경 고정 |
 | `JPA_SHOW_SQL` | `true` | 실행 SQL 로그 |
 
 ### 인증 · 정책
@@ -307,18 +307,11 @@ JVM 힙은 `compose.prod.yaml` 의 `JAVA_OPTS` 가 `MaxRAMPercentage=35` 로 묶
 스키마의 정본은 [db/migration](../src/main/resources/db/migration) 의 Flyway 마이그레이션이고,
 데이터 모델 문서는 [ERD.md](../docs/ERD.md) 다.
 
-`JPA_DDL_AUTO` 와 `FLYWAY_ENABLED` 는 **스키마 소유자를 정하는 한 쌍**이라 항상 같이 움직인다.
+**전 환경이 `JPA_DDL_AUTO=validate` · `FLYWAY_ENABLED=true` 고정이다.** 로컬도 운영도 예외가 없다.
+Flyway 가 스키마를 소유하고 Hibernate 는 대조만 하며, 엔티티와 스키마가 어긋나면 **기동이 실패한다.**
+엔티티를 고쳤다면 마이그레이션 파일을 함께 추가한다.
 
-| 상황 | `JPA_DDL_AUTO` | `FLYWAY_ENABLED` | 의미 |
-| --- | --- | --- | --- |
-| 기본 · 출시 | `validate` | `true` | Flyway 가 스키마를 소유하고, Hibernate 는 대조만 한다 |
-| 출시 전 개발 중 | `update` | `false` | 엔티티 변경이 스키마에 바로 반영된다 |
-
-> 현재 [.env.local.example](env/.env.local.example) 은 개발 편의를 위해 `JPA_DDL_AUTO=update` 로 배포되어 있다.
-> 출시 시점에는 `validate` / `true` 조합으로 되돌린다.
-
-`update` 는 컬럼을 **추가만** 하고 삭제·타입 축소는 하지 않는다. 엔티티에서 필드를 빼면 DB 에 죽은 컬럼이 남으므로,
-그럴 때 `./run.sh reset-db` 로 한 번 비운다. `V1__init.sql` 을 수정했을 때도 checksum 불일치로 기동이 거부되므로 같은 명령을 쓴다.
+`V1__init.sql` 을 수정하면 checksum 불일치로 기동이 거부된다. 그럴 때는 `./run.sh reset-db` 로 한 번 비운다.
 
 ### 초기 데이터 — 우표 시드
 

--- a/infra/RUN.md
+++ b/infra/RUN.md
@@ -162,8 +162,7 @@ export TESTCONTAINERS_RYUK_DISABLED=true
 | Caddy 기동 실패 | 80/443 을 다른 프로세스가 점유 | `lsof -nP -iTCP:80 -sTCP:LISTEN` 로 확인 후 중지, 또는 `APP_HTTP_PORT` 변경 |
 | 브라우저 인증서 경고 | Caddy 내장 CA(자체 서명) | `./run.sh trust` (macOS) |
 | `WeakKeyException` 으로 기동 실패 | `JWT_SECRET` 이 32바이트 미만이거나 비어 있음 | `openssl rand -base64 48` 로 생성해 교체 |
-| `Schema-validation: missing column` | 엔티티는 바뀌었는데 스키마가 그대로 | 마이그레이션 추가, 또는 개발 중이라면 `./run.sh reset-db` |
-| 엔티티에서 지운 컬럼이 DB 에 남음 | `update` 는 컬럼을 삭제하지 않는다 | `./run.sh reset-db` |
+| `Schema-validation: missing column` | 엔티티는 바뀌었는데 마이그레이션이 없다 | 마이그레이션 파일 추가 |
 | Flyway checksum 불일치 | 적용된 마이그레이션 파일을 수정 | `./run.sh reset-db` |
 | 컨테이너를 지웠는데 옛 데이터가 남음 | 호스트 바인드 마운트라 `down -v` 로는 안 지워진다 | `./run.sh clean` |
 | Testcontainers 가 Docker 를 못 찾음 | Docker 가 안 떠 있거나 소켓 경로가 자동 탐지 대상 밖 | `colima start` 후 재시도, 그래도 안 되면 §4 의 환경변수 |

--- a/infra/env/.env.local.example
+++ b/infra/env/.env.local.example
@@ -25,13 +25,9 @@ MYSQL_DATA_PATH=../../../mount/mysql
 MINIO_DATA_PATH=../../../mount/minio
 
 # ===== JPA =====
-# 스키마는 Flyway 가 소유한다. 전 환경 validate 고정.
-# 개발 중에는 update 로 엔티티 변경을 스키마에 바로 반영한다. 출시 전까지만 쓰는 설정이다.
-# create 와 달리 기존 데이터를 지우지 않지만, 컬럼 추가만 하고 삭제·타입 축소는 하지 않는다.
-# 즉 엔티티에서 필드를 빼도 DB 에는 죽은 컬럼이 남는다. 그럴 때는 ./run.sh reset-db 로 한 번 비운다.
-# Flyway 와 동시에 켜면 스키마 소유자가 둘이 되므로 두 값은 항상 같이 움직인다.
-# 출시 시점에 JPA_DDL_AUTO=validate / FLYWAY_ENABLED=true 로 되돌린다.
-JPA_DDL_AUTO=update
+# 스키마는 Flyway 가 소유하고 Hibernate 는 대조만 한다. 어긋나면 기동이 실패한다.
+# 엔티티를 고쳤다면 마이그레이션 파일을 함께 추가한다.
+JPA_DDL_AUTO=validate
 FLYWAY_ENABLED=true
 JPA_SHOW_SQL=true
 

--- a/infra/env/.env.prod.example
+++ b/infra/env/.env.prod.example
@@ -17,14 +17,9 @@ MYSQL_PASSWORD=CHANGE_ME
 MYSQL_ROOT_PASSWORD=CHANGE_ME
 
 # ===== JPA =====
-# 운영에서 create/create-drop 은 절대 금지 (기동할 때마다 테이블이 날아간다)
-# create | update | validate | none
-# 개발 중에는 update 로 엔티티 변경을 스키마에 바로 반영한다. 출시 전까지만 쓰는 설정이다.
-# create 와 달리 기존 데이터를 지우지 않지만, 컬럼 추가만 하고 삭제·타입 축소는 하지 않는다.
-# 즉 엔티티에서 필드를 빼도 DB 에는 죽은 컬럼이 남는다. 그럴 때는 ./run.sh reset-db 로 한 번 비운다.
-# Flyway 와 동시에 켜면 스키마 소유자가 둘이 되므로 두 값은 항상 같이 움직인다.
-# 출시 시점에 JPA_DDL_AUTO=validate / FLYWAY_ENABLED=true 로 되돌린다.
-JPA_DDL_AUTO=update
+# 스키마는 Flyway 가 소유하고 Hibernate 는 대조만 한다. 어긋나면 기동이 실패한다.
+# 엔티티를 고쳤다면 마이그레이션 파일을 함께 추가한다.
+JPA_DDL_AUTO=validate
 FLYWAY_ENABLED=true
 JPA_SHOW_SQL=false
 

--- a/run.sh
+++ b/run.sh
@@ -61,11 +61,8 @@ case "${1:-up}" in
     $COMPOSE down
     ;;
   reset-db)
-    # 스키마를 통째로 비우고 다시 만든다. 쓰는 상황이 두 가지다.
-    #   1) ddl-auto=update 로 개발 중 엔티티에서 컬럼을 지웠을 때. update 는 컬럼을
-    #      추가만 하고 지우지 않아, 비우지 않으면 DB 에 죽은 컬럼이 계속 남는다.
-    #   2) Flyway 를 켠 상태에서 V1__init.sql 을 고쳤을 때. checksum 불일치로 기동이 거부된다.
-    # 비운 뒤 스키마를 다시 만드는 주체는 설정에 따라 Flyway 이거나 Hibernate 다.
+    # 스키마를 통째로 비우고 Flyway 로 다시 만든다. V1__init.sql 을 고쳤을 때 쓴다.
+    # checksum 이 달라지면 Flyway 가 기동을 거부한다.
     #
     # DROP DATABASE 가 아니라 테이블만 지우는 이유는, 스키마를 지우면 그 스키마에
     # 걸린 사용자 권한까지 함께 사라져 앱이 접속하지 못하기 때문이다.

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,12 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      # 스키마는 Flyway 가 소유한다. 기본값은 validate 로 고정한다.
-      # 기본값을 절대 바꾸지 않는다 — 키가 빠진 환경에서 스키마가 조용히 뒤집힌다.
-      #
-      # 출시 전 개발 단계에 한해 .env 에서만 update 로 내려 쓴다. 그때는 FLYWAY_ENABLED=false
-      # 를 반드시 함께 내려 스키마 소유자를 하나로 유지한다. update 는 컬럼을 추가할 뿐
-      # 삭제하거나 타입을 줄이지 않으므로, 컬럼을 지웠다면 ./run.sh reset-db 로 한 번 비운다.
+      # 스키마는 Flyway 가 소유하고 Hibernate 는 대조만 한다. 전 환경 validate 로 고정한다.
       ddl-auto: ${JPA_DDL_AUTO:validate}
     show-sql: ${JPA_SHOW_SQL:true}
     # 응답 DTO 는 서비스 트랜잭션 안에서 조립하므로 뷰 렌더링 시점에 쿼리가 나갈 일이 없다.
@@ -28,8 +23,7 @@ spring:
       hibernate:
         format_sql: true
 
-  # 마이그레이션이 소유한 스키마와 Hibernate 가 만든 스키마는 동시에 존재할 수 없다.
-  # ddl-auto=create 로 개발하는 동안에는 false 로 내린다.
+  # 스키마 소유자는 Flyway 하나다.
   flyway:
     enabled: ${FLYWAY_ENABLED:true}
     baseline-on-migrate: true


### PR DESCRIPTION
## 변경 내용

- `docs/카카오회원가입.md`, `docs/애플회원가입.md` 를 추적 대상에 추가했다. 이전에 실제 식별자·운영 주소가 들어 있어 `.gitignore` 로 제외했던 문서인데, Team ID 와 운영 주소를 플레이스홀더(`{SITE_ADDRESS}`, `<1번의 Team ID>`)로 바꿔 실제 값 없이 커밋했다. 실제 값은 `infra/env/.env.prod` 에만 둔다.
- `JPA_DDL_AUTO` 를 전 환경 `validate` 로 고정했다 (c02da1b).

## 확인 사항

- 문서 2종에 실제 Team ID·운영 주소가 남아 있지 않다.
- 스키마는 Flyway(`V1__init.sql`)가 관리하므로 `validate` 로 고정해도 기동에 영향이 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)