### PR TITLE
[FEAT] mock 사용자 시드 · 소셜 로그인 state 검증 · 버전 응답 보정

### DIFF
--- a/.claude/skills/seed-data/SKILL.md
+++ b/.claude/skills/seed-data/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: seed-data
+description: 시드 데이터(우표·목 사용자)를 만들거나 고칠 때 사용. 시드 클래스를 어디에 두는지, 멱등성·기동 차단 금지·활성화 플래그·실행 순서 규칙, 목 사용자 시드와 로컬 토큰 발급 스크립트 사용법을 다룬다. "시드 추가", "테스트 데이터 넣어줘", "목 유저", "토큰 발급 스크립트" 요청에 해당.
+---
+
+# 시드 데이터 규칙
+
+기동할 때 애플리케이션이 스스로 채워 넣는 데이터를 다룬다.
+스키마는 Flyway 가 소유하고, **행(row)은 시더가 소유한다.** 마이그레이션 SQL 에 INSERT 를 넣지 않는다.
+
+## 파일 배치
+
+```
+src/main/java/com/dearjolly/server/global/seed/
+├── SeedOrder.java              # 시더 실행 순서 상수
+├── {대상}Seed*.java            # 시드 한 건을 나타내는 record
+├── {대상}SeedData.java         # 코드에 박아 두는 시드 원본 (필요할 때만)
+├── {대상}SeedProperties.java   # dearjolly.seed.{대상} 설정
+├── {대상}SeedWriter.java       # @Transactional DB 반영
+└── {대상}Seeder.java           # ApplicationRunner. 켜짐 여부 판단 + 로깅
+src/main/resources/seed/        # 코드에 담을 수 없는 원본 (우표 이미지 등)
+infra/scripts-local/seed/       # 로컬에서만 돌리는 시드 보조 스크립트
+```
+
+- 시드는 도메인이 아니라 `global/seed` 에 모은다. 여러 도메인의 엔티티를 가로질러 만들기 때문이다.
+- **Seeder 와 Writer 를 반드시 나눈다.** `ApplicationRunner` 는 트랜잭션 밖에서 돌기 때문에,
+  DB 작업은 `@Transactional` 이 붙은 Writer 빈에 두어야 프록시를 타고 트랜잭션이 열린다.
+
+## 시더가 지켜야 할 네 가지
+
+### 1. 멱등성 — 몇 번을 돌려도 같은 상태로 수렴한다
+
+블루그린 배포·재기동·`./run.sh restart` 마다 시더가 다시 돈다. 행이 불어나면 안 된다.
+
+- 행마다 **자연키**를 정하고, 그 키로 먼저 찾은 뒤 없을 때만 만든다.
+  - 우표: `STAMPS.name`
+  - 목 사용자: `(oauth_provider, oauth_id)`
+  - 목 사용자의 편지: `LETTERS.content`
+- 이미 있는 행은 **필요한 필드만 갱신**한다 (예: 우표 이미지 키가 바뀌었을 때).
+- 자연키를 바꾸면 예전 행이 남고 새 행이 하나 더 생긴다. 시드 원본을 고칠 때 이 점을 명시한다.
+
+### 2. 실패해도 기동을 막지 않는다
+
+`run()` 전체를 `try/catch` 로 감싸고 `log.error` 만 남긴다.
+시드가 안 됐다고 서버가 못 뜨면 무중단 배포가 통째로 멈춘다.
+
+```java
+try {
+    seed();
+} catch (Exception e) {
+    log.error("... 시드에 실패했다.", e);
+}
+```
+
+전제가 안 갖춰진 경우(버킷 없음, 우표 없음)는 예외가 아니라 `log.warn` + 건너뛰기로 처리한다.
+
+### 3. 켜고 끌 수 있다
+
+`dearjolly.seed.{대상}.enabled` 를 `{대상}SeedProperties` 에 두고, 시더 첫 줄에서 확인한다.
+
+- **운영에 있어도 되는 시드**(우표처럼 서비스 데이터)만 기본값 `true`.
+- **테스트 편의용 시드**(목 사용자처럼 진짜 계정처럼 보이는 데이터)는 기본값 `false` 로 두고,
+  `infra/env/.env.local.example` 에서만 켠다. `.env.prod.example` 에는 키를 넣지 않는다.
+- 테스트가 시드에 영향받지 않도록 `src/test/resources/application.yaml` 에서 명시적으로 끈다.
+
+### 4. 순서는 `SeedOrder` 로 고정한다
+
+`ApplicationRunner` 는 여러 개면 순서가 정해져 있지 않다. 시더끼리 의존이 있으면
+`@Order(SeedOrder.XXX)` 로 못 박고, 상수 옆에 왜 그 순서인지 적는다.
+
+## 시드 원본을 어디에 둘지
+
+| 원본 | 위치 | 이유 |
+|---|---|---|
+| 바이너리 (이미지 등) | `src/main/resources/seed/` | 코드에 담을 수 없다 |
+| 텍스트 (편지 본문 등) | `{대상}SeedData.java` 의 `List` 상수 | 컴파일 시점에 깨지고, 어차피 재기동해야 반영된다 |
+| 환경마다 달라지는 값 | `{대상}SeedProperties` | `.env` 로 덮어쓸 수 있어야 한다 |
+
+## 목 사용자 시드
+
+`MockUserSeeder` 가 소셜 로그인 없이 인증 API 를 두드릴 수 있는 계정 하나를 만든다.
+약관 동의·닉네임 등록까지 끝난 상태라 온보딩 인터셉터를 그대로 통과한다.
+
+- 편지는 `MockUserSeedData.LETTERS` 에 있다. 피드백이 붙은 편지는 우표·교정 조각·학습 팁까지
+  완성된 상태로 들어가고, `correctedContent` 가 없는 편지는 `SUBMITTED` 로 남는다.
+- 편지를 늘리거나 고칠 때는 `MockUserSeedDataTest` 가 편지 작성 API 의 제약
+  (500자·영문·우표 존재·팁 3개)을 대신 검증한다. 새 제약이 생기면 이 테스트에 추가한다.
+- 우표를 STAMPS 에서 찾아 붙이므로 `StampSeeder` 뒤에 돌아야 한다 (`SeedOrder.MOCK_USER`).
+
+### 토큰 발급
+
+```bash
+./infra/scripts-local/seed/mock-token.sh            # 사람이 읽는 형식
+eval $(./infra/scripts-local/seed/mock-token.sh --export)
+./infra/scripts-local/seed/mock-token.sh --json     # jq 로 파싱
+./infra/scripts-local/seed/mock-token.sh --user-id 3
+```
+
+`.env.local` 의 `JWT_SECRET` 으로 서버 `JwtProvider` 와 같은 HS256 토큰을 로컬에서 직접 서명하고,
+Refresh Token 은 `USERS.refresh_token` 에도 기록해 `/api/v1/auth/reissue` 가 동작하게 한다.
+
+**서버에 토큰 발급용 엔드포인트를 만들지 않는다.** 테스트 편의로 뚫은 구멍은 운영까지 따라간다.
+같은 이유로 이 스크립트는 `infra/scripts-local/` 아래에 두고 컨테이너 이미지에 넣지 않는다.
+
+## 하지 말 것
+
+- 마이그레이션 SQL 에 `INSERT` 를 넣는 것 — 체크섬이 굳어 고칠 수 없게 된다.
+- 시드에서 `deleteAll()` 후 다시 넣는 것 — 사용자가 만든 데이터를 지운다.
+- 목 사용자 시드를 운영 환경 설정에 넣는 것.
+- 실제 발급된 토큰·키·비밀번호를 시드 데이터나 예제 `.env` 에 적는 것.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Dear Jolly 백엔드 서버. Java 21 / Spring Boot 3.5.7 / Spring Data JPA / MyS
 | Request/Response DTO 작성, 입력값 검증 추가 | `spring-dto` |
 | 예외 던지기, 새 에러 코드 추가, 에러 응답 포맷 | `spring-exception` |
 | 테스트 코드 작성 | `spring-test` |
+| 시드 데이터 추가·수정, 목 사용자·로컬 토큰 발급 | `seed-data` |
 | 코드 리뷰, PR 점검, 컨벤션 준수 확인 | `spring-code-review` |
 | `docs/API명세.md` 작성·갱신, 구현 완료 표기 변경 | `api-spec-doc` |
 | 주석·Javadoc 을 달지 말지 판단 | `code-comment` |

--- a/README.md
+++ b/README.md
@@ -104,3 +104,15 @@ flowchart TB
 | [docs/API명세.md](docs/API명세.md) | 요청/응답 계약의 정본 |
 | [docs/ERD.md](docs/ERD.md) | 데이터 모델의 정본 |
 | [infra/README.md](infra/README.md) | 구축 · 배포 · 운영 |
+
+## 로컬 시드 데이터 ✨
+
+인증이 필요한 API 를 소셜 로그인 없이 시험하도록, **로컬에서만** 목 사용자 한 명(약관 동의·닉네임 등록 완료, 편지 몇 통)을 시드로 넣는다.
+기본값은 꺼짐이고 `infra/env/.env.local` 에서 `MOCK_USER_SEED_ENABLED=true` 로 켠 뒤 `./run.sh restart` 로 반영한다. 몇 번을 재기동해도 데이터가 불어나지 않는다.
+
+```bash
+eval $(./infra/scripts-local/seed/mock-token.sh --export)   # Access·Refresh Token 발급
+curl -k -H "Authorization: Bearer $ACCESS_TOKEN" https://localhost:8080/api/v1/home
+```
+
+자세한 내용은 [infra/RUN.md](infra/RUN.md) 를 본다.

--- a/docs/API명세.md
+++ b/docs/API명세.md
@@ -909,7 +909,8 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
 
 - 앱 최소 지원 버전과 정책 페이지 URL 을 조회한다. **로그인 전에도 호출할 수 있다.**
 - 앱 버전이 `minSupportedVersion` 미만이면 강제 업데이트를 유도한다. **판정은 앱이 한다.** 서버는 앱 버전을 받지 않는다.
-- `forceUpdate` 는 참고용 보조 신호다. 앱은 자기 버전과 `minSupportedVersion` 을 직접 비교한다.
+- `forceUpdate` 는 **서버가 켜고 끄는 보조 신호**이며 `latestVersion` · `minSupportedVersion` 에서 계산한 값이 아니다. 두 값이 같아도 자동으로 `true` 가 되지 않는다.
+- 앱은 `forceUpdate` 를 믿고 판정하지 않는다. 자기 버전과 `minSupportedVersion` 을 직접 비교한다.
 - **공지사항 · 개인정보처리방침 · 이용약관은 별도 API 가 없다.** 이 응답의 링크를 웹뷰로 연다.
 - 설정 화면 하단의 `현재 버전` 표기는 앱 로컬 값이며 이 응답과 무관하다.
 - `platform` 이 `IOS` · `AOS` 가 아니면 `COMMON_001` 이다.

--- a/docs/API명세.md
+++ b/docs/API명세.md
@@ -2,7 +2,7 @@
 
 | 항목 | 내용 |
 | --- | --- |
-| 최종 갱신 | 2026-08-22 |
+| 최종 갱신 | 2026-08-23 |
 | Base URL | `https://{host}` |
 | 인증 | `Authorization: Bearer {accessToken}` |
 | Content-Type | `application/json; charset=UTF-8` |
@@ -686,7 +686,7 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
     "date": "2025-11-01",
     "originalContent": "I got flowers from a friend today...",
     "status": "FEEDBACK_COMPLETED",
-    "stampImage": "http://localhost:9000/dear-jolly-stamps/stamp/%EA%BD%83_%EC%9E%A5%EB%AF%B8.png",
+    "stampImage": "https://{host}/dear-jolly-stamps/stamp/%EA%BD%83_%EC%9E%A5%EB%AF%B8.png",
     "feedback": {
         "feedbackId": 101,
         "correctedContent": "I received flowers from a friend today...",
@@ -801,7 +801,7 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
             "summary": "I got flowers from a friend today. It really touch",
             "status": "FEEDBACK_COMPLETED",
             "isRead": false,
-            "stampImage": "http://localhost:9000/dear-jolly-stamps/stamp/%EA%BD%83_%EC%9E%A5%EB%AF%B8.png"
+            "stampImage": "https://{host}/dear-jolly-stamps/stamp/%EA%BD%83_%EC%9E%A5%EB%AF%B8.png"
         },
         {
             "letterId": 12,
@@ -809,7 +809,7 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
             "summary": "Hi! Jolly. I made a new friend at a Halloween part",
             "status": "FEEDBACK_COMPLETED",
             "isRead": true,
-            "stampImage": "http://localhost:9000/dear-jolly-stamps/stamp/%ED%98%B8%EB%B0%95_%ED%95%A0%EB%A1%9C%EC%9C%88.png"
+            "stampImage": "https://{host}/dear-jolly-stamps/stamp/%ED%98%B8%EB%B0%95_%ED%95%A0%EB%A1%9C%EC%9C%88.png"
         },
         {
             "letterId": 11,
@@ -817,7 +817,7 @@ Bearer eyJhbGciOiJIUzI1NiJ9...
             "summary": "Lately I've been really worried about my new job a",
             "status": "SUBMITTED",
             "isRead": false,
-            "stampImage": "http://localhost:9000/dear-jolly-stamps/stamp/soon.png"
+            "stampImage": "https://{host}/dear-jolly-stamps/stamp/soon.png"
         }
     ],
     "hasNext": true
@@ -1021,6 +1021,8 @@ GET /api/v1/version
 | `COMMON_004` | 429 | 요청이 너무 많습니다. 잠시 후 다시 시도해주세요. | 요청 횟수 초과 |
 | `COMMON_005` | 500 | 일시적인 오류가 발생했습니다. | 서버 오류 |
 
+- `COMMON_002` 는 **인증을 통과한 요청에만** 나간다. 인증이 필요한 경로에서 토큰이 없거나 유효하지 않으면, 경로가 없더라도 `AUTH_005`(401) 가 먼저 나간다.
+
 ---
 
 # 5. 그 외 규약 정의
@@ -1056,6 +1058,8 @@ GET /api/v1/version
 - [필수] `status` (Integer): HTTP 상태 코드
 - [필수] `code` (String): `{도메인}_{일련번호}` 형식 (`AUTH_`, `USER_`, `LETTER_`, `COMMON_`)
 - [필수] `message` (String): 사용자에게 그대로 보여줘도 되는 문구
+
+- **같은 `code` 라도 `message` 는 상황에 따라 더 구체적인 문구로 내려올 수 있다.** 앱은 `code` 로만 분기하고 `message` 는 받은 그대로 표시한다.
 
 ## 3) 시간 · 타임존 정의
 

--- a/docs/API명세.md
+++ b/docs/API명세.md
@@ -48,6 +48,7 @@
 - **앱 SDK 로 받은 소셜 토큰을 서버에 전달하는 방식은 지원하지 않는다.**
 - 유저는 `(provider + provider 회원 식별자)` 로 구분한다. 이메일이 같아도 카카오와 애플은 별개 계정이다.
 - `provider` 는 대소문자를 가리지 않는다. `KAKAO` · `APPLE` 중 어느 것도 아니면 `COMMON_001` 이다.
+- **이 주소를 연 뒤 10분 안에 provider 로그인을 마쳐야 한다.** 넘기면 콜백에서 `AUTH_002` 가 나가므로 앱은 로그인을 처음부터 다시 시작한다.
 
 ### [스펙]
 
@@ -94,7 +95,8 @@ Location: https://kauth.kakao.com/oauth/authorize?client_id=...&redirect_uri=...
 - 가입 직후에는 약관 동의 이력이 없고 닉네임이 비어 있다.
 - 로그인은 **기기 1대만 유지**된다. 새로 로그인하면 이전 로그인은 풀린다.
 - **탈퇴한 계정으로 다시 로그인하면 항상 신규 가입**(`isNewUser=true`)이며, 이전 편지는 복원되지 않는다.
-- 콜백 단계의 실패는 딥링크가 아니라 **JSON 에러 응답**으로 나간다. 인가 코드 검증에 실패하면 `AUTH_002`, 카카오 서버와 통신하지 못하면 `AUTH_003` 이다.
+- 콜백 단계의 실패는 딥링크가 아니라 **JSON 에러 응답**으로 나간다. 인가 코드나 `state` 검증에 실패하면 `AUTH_002`, 카카오 서버와 통신하지 못하면 `AUTH_003` 이다.
+- `state` 는 **로그인 시작 때 서버가 발급한 값이어야 하고 10분이 지나면 만료**된다. 비었거나 위조됐거나 만료됐으면 `AUTH_002` 다.
 
 ### [스펙]
 
@@ -109,7 +111,7 @@ GET /api/v1/auth/kakao/callback
 **Request Parameter**
 
 - [필수] `code` (String): 카카오가 발급한 인가 코드
-- [선택] `state` (String): 로그인 시작 때 서버가 붙여 보낸 값
+- [필수] `state` (String): 로그인 시작 때 서버가 붙여 보낸 값
 
 ### [성공 Response 302]
 
@@ -162,7 +164,7 @@ Location: dearjolly://auth/callback
 - 애플이 호출하는 주소다. **앱이 직접 호출하지 않는다.** 애플이 `form_post` 로 보내기 때문에 `POST` 다.
 - 응답 형태와 앱 분기 규칙은 [2) GET /api/v1/auth/kakao/callback](#2-get-apiv1authkakaocallback-) 과 완전히 같다.
 - 애플에서 이메일 제공을 거부한 유저는 **이메일이 비어 있다**(`null`). 서버가 대체 주소를 지어내지 않는다.
-- 인가 코드 · `id_token` 검증에 실패하면 `AUTH_002`, 애플 서버와 통신하지 못하면 `AUTH_003` 이다.
+- 인가 코드 · `id_token` · `state` 검증에 실패하면 `AUTH_002`, 애플 서버와 통신하지 못하면 `AUTH_003` 이다.
 
 ### [스펙]
 
@@ -178,7 +180,7 @@ POST /api/v1/auth/apple/callback
 
 - [필수] `code` (String): 애플이 발급한 인가 코드
 - [필수] `id_token` (String): 회원 식별자와 이메일이 담긴 토큰
-- [선택] `state` (String): 로그인 시작 때 서버가 붙여 보낸 값
+- [필수] `state` (String): 로그인 시작 때 서버가 붙여 보낸 값
 
 ### [성공 Response 302]
 

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -233,6 +233,13 @@ stampImage = ${MINIO_PUBLIC_ENDPOINT} + "/" + ${MINIO_BUCKET} + "/" + image_key
 | 재실행 | 같은 키에 같은 크기로 올라가 있으면 업로드를 건너뛰고, 같은 `name` 행이 있으면 `image_key` 가 다를 때만 갱신한다 |
 
 `soon` 은 편지 등록 시점에 붙는 "준비 중" 우표다. `stamp_id = 1` 에 고정되고 LLM 우표 선택 후보에서는 빠진다 (A9-1).
+
+#### API 테스트용 목 사용자 시드 (로컬 전용)
+
+`global/seed/MockUserSeeder` 가 약관 동의·닉네임까지 끝난 계정 하나와 편지 몇 통을 넣는다.
+`USERS` · `TERMS_AGREEMENTS` · `LETTERS` · `FEEDBACKS` · `CORRECTION_SEGMENTS` · `FEEDBACK_TIPS` 를 가로질러 만들며,
+`(oauth_provider, oauth_id)` 와 `LETTERS.content` 를 자연키로 삼아 재기동해도 행이 불어나지 않는다.
+기본값은 꺼짐이고 `.env.local` 에서만 켠다. 실행 방법은 [infra/RUN.md](../infra/RUN.md) 를 본다.
 편지가 실제로 받는 우표는 피드백이 완료되는 시점에 정해진다.
 
 파일명이 곧 `name` 이자 파일 키라서 **파일을 넣는 것 외에 채울 값이 없다.** 우표를 추가하려면 이미지를 이 폴더에 두고 배포하면 된다.

--- a/infra/RUN.md
+++ b/infra/RUN.md
@@ -79,6 +79,40 @@ docker compose -f infra/docker/compose.yaml --env-file infra/env/.env.local ps
 DB·이미지 데이터는 컨테이너가 아니라 호스트의 `dear-jolly/mount/{mysql,minio}` 에 쌓인다.
 컨테이너를 지워도 남고, 지우려면 `./run.sh clean` 을 쓴다.
 
+### 목 사용자로 API 두드리기
+
+인증이 필요한 API 를 소셜 로그인 없이 시험하려고, 기동할 때 계정 하나를 시드로 넣는다.
+약관 동의·닉네임 등록까지 끝난 상태라 온보딩 인터셉터를 그대로 통과하고,
+피드백까지 완료된 편지 몇 통과 아직 제출 상태인 편지가 함께 들어간다.
+
+`.env.local` 에서 켠다 (기본값은 꺼짐, 운영에는 넣지 않는다).
+
+```bash
+MOCK_USER_SEED_ENABLED=true
+MOCK_USER_OAUTH_ID=mock-user     # 계정을 구분하는 자연키
+```
+
+껐다 켠 뒤 `./run.sh restart` 로 시드를 돌린다.
+같은 `oauth_id`·같은 편지 본문은 다시 만들지 않으므로 몇 번을 재기동해도 데이터가 불어나지 않는다.
+
+토큰은 로컬 스크립트로 발급한다. `.env.local` 의 `JWT_SECRET` 으로 서버와 같은 HS256 토큰을 서명하고,
+Refresh Token 은 `USERS.refresh_token` 에도 기록해 `/api/v1/auth/reissue` 까지 그대로 시험할 수 있다.
+
+```bash
+./infra/scripts-local/seed/mock-token.sh              # 사람이 읽는 형식
+eval $(./infra/scripts-local/seed/mock-token.sh --export)
+curl -k -H "Authorization: Bearer $ACCESS_TOKEN" https://localhost:8080/api/v1/home
+
+./infra/scripts-local/seed/mock-token.sh --json       # jq 로 파싱
+./infra/scripts-local/seed/mock-token.sh --user-id 3  # 다른 계정으로 발급
+```
+
+| 증상 | 원인 |
+| --- | --- |
+| `목 사용자(...)가 없습니다` | 시드가 꺼져 있거나 아직 재기동하지 않았다 |
+| 편지에 우표가 안 붙는다 | 우표 시드가 먼저 끝나야 한다. `STAMP_SEED_ENABLED` 와 MinIO 버킷을 확인한다 |
+| 401 `ACCESS_TOKEN_INVALID` | `JWT_SECRET` 을 바꾸고 앱을 재기동하지 않았다 |
+
 ---
 
 ## 3. 원격 실행

--- a/infra/env/.env.local.example
+++ b/infra/env/.env.local.example
@@ -76,3 +76,13 @@ MINIO_PUBLIC_ENDPOINT=https://localhost:8080
 # 기동 시 seed/stamps 이미지를 MinIO 에 올리고 STAMPS 행을 맞춘다. 이미 있으면 건너뛴다.
 # 시드를 완전히 끄려면 false
 STAMP_SEED_ENABLED=true
+
+# ===== 목 사용자 시드 (API 테스트용, 로컬 전용) =====
+# 약관 동의·닉네임까지 끝난 계정 하나와 편지 몇 통을 넣는다. 재기동해도 같은 데이터로 수렴한다.
+# 운영에는 절대 켜지 않는다 (.env.prod 에는 두지 않는다).
+MOCK_USER_SEED_ENABLED=true
+MOCK_USER_OAUTH_PROVIDER=KAKAO
+MOCK_USER_OAUTH_ID=mock-user
+MOCK_USER_EMAIL=mock@dearjolly.local
+# 닉네임은 영문·숫자 20자 이내여야 한다 (UserValidationConstants.NICKNAME_REGEX)
+MOCK_USER_NICKNAME=jolly

--- a/infra/env/.env.prod.example
+++ b/infra/env/.env.prod.example
@@ -108,6 +108,7 @@ ALLOWED_SSH_CIDR=0.0.0.0/0   # SSH 허용 대역. 가능하면 본인 IP/32 로 
 # 비워 두거나 줄을 지우면 주석의 기본값으로 뜬다. 버전 상향은 이 값만 올리고 재배포하면 된다.
 APP_LATEST_VERSION=1.0.0            # 기본값 1.0.0 — 스토어에 올라간 최신 버전
 APP_MIN_SUPPORTED_VERSION=1.0.0     # 기본값 1.0.0 — 이 버전 미만이면 앱이 강제 업데이트를 유도한다
+APP_FORCE_UPDATE=false              # 기본값 false — 강제 업데이트 캠페인 스위치. 켜면 version 응답의 forceUpdate 가 true 로 나간다
 # 아래 4개는 한쪽 플랫폼만 심사에 걸려 버전이 벌어질 때만 채운다. 비어 있으면 위 공통 값을 쓴다.
 APP_LATEST_VERSION_IOS=             # 기본값 없음 — 채우면 iOS 만 공통 값을 덮어쓴다
 APP_MIN_SUPPORTED_VERSION_IOS=      # 기본값 없음

--- a/infra/scripts-local/seed/mock-token.sh
+++ b/infra/scripts-local/seed/mock-token.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# 목 사용자(MockUserSeeder 가 넣은 계정)의 Access·Refresh 토큰을 로컬에서 직접 발급한다.
+#
+# 소셜 로그인을 거치지 않고 인증이 필요한 API 를 두드리기 위한 것이다. 서버에 토큰 발급용
+# 엔드포인트를 열면 그 구멍이 운영까지 따라가므로, 대신 .env.local 의 JWT_SECRET 으로
+# 서버와 똑같은 HS256 토큰을 여기서 서명한다.
+#
+# 발급한 Refresh Token 은 USERS.refresh_token 에 함께 기록한다. 그래야 /api/v1/auth/reissue 가
+# 저장된 값과 대조해 재발급을 내준다.
+#
+# 사용법:
+#   ./infra/scripts-local/seed/mock-token.sh              # 사람이 읽는 형식으로 출력
+#   ./infra/scripts-local/seed/mock-token.sh --export     # eval $(...) 로 셸에 넣을 형식
+#   ./infra/scripts-local/seed/mock-token.sh --json       # jq 로 파싱할 형식
+#   ./infra/scripts-local/seed/mock-token.sh --user-id 3  # 목 사용자 말고 특정 user_id 로 발급
+set -euo pipefail
+
+SCRIPT_NAME="mock-token"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+ENV_FILE="infra/env/.env.local"
+MYSQL_CONTAINER="dear-jolly-mysql"
+
+die() { echo "[${SCRIPT_NAME}] $*" >&2; exit 1; }
+log() { echo "[${SCRIPT_NAME}] $*" >&2; }
+
+# KEY=VALUE 에서 값만 추출 (인라인 주석·후행 공백 제거)
+read_env() {
+  grep -E "^$1=" "$ENV_FILE" | head -1 | cut -d= -f2- \
+    | sed -E 's/[[:space:]]+#.*$//; s/[[:space:]]+$//'
+}
+
+# ── 1. 인자 ────────────────────────────────────────────────────
+FORMAT="human"
+USER_ID=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --export) FORMAT="export" ;;
+    --json)   FORMAT="json" ;;
+    --user-id) shift; USER_ID="${1:-}"; [ -n "$USER_ID" ] || die "--user-id 뒤에 값이 필요합니다." ;;
+    -h|--help) sed -n '2,17p' "$0"; exit 0 ;;
+    *) die "알 수 없는 옵션: $1" ;;
+  esac
+  shift
+done
+
+# ── 2. 전제 확인 ───────────────────────────────────────────────
+command -v openssl >/dev/null || die "openssl 이 필요합니다."
+command -v docker  >/dev/null || die "docker 가 필요합니다."
+[ -f "$ENV_FILE" ] || die "${ENV_FILE} 가 없습니다. ./run.sh 를 한 번 실행해 만드세요."
+docker ps --format '{{.Names}}' | grep -qx "$MYSQL_CONTAINER" \
+  || die "${MYSQL_CONTAINER} 가 떠 있지 않습니다. ./run.sh 를 먼저 실행하세요."
+
+JWT_SECRET=$(read_env JWT_SECRET)
+[ -n "$JWT_SECRET" ] || die "${ENV_FILE} 에 JWT_SECRET 이 없습니다."
+ACCESS_EXPIRE_MS=$(read_env JWT_ACCESS_EXPIRE);   ACCESS_EXPIRE_MS="${ACCESS_EXPIRE_MS:-1800000}"
+REFRESH_EXPIRE_MS=$(read_env JWT_REFRESH_EXPIRE); REFRESH_EXPIRE_MS="${REFRESH_EXPIRE_MS:-1209600000}"
+
+MYSQL_DATABASE=$(read_env MYSQL_DATABASE)
+MYSQL_USER=$(read_env MYSQL_USER)
+MYSQL_PASSWORD=$(read_env MYSQL_PASSWORD)
+OAUTH_PROVIDER=$(read_env MOCK_USER_OAUTH_PROVIDER); OAUTH_PROVIDER="${OAUTH_PROVIDER:-KAKAO}"
+OAUTH_ID=$(read_env MOCK_USER_OAUTH_ID);             OAUTH_ID="${OAUTH_ID:-mock-user}"
+
+# 컨테이너 안에서 실행한다. -N 은 헤더 없이, 경고는 stderr 로 흘려보낸다.
+mysql_query() {
+  docker exec -i "$MYSQL_CONTAINER" \
+    mysql -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" -N -B -e "$1" "$MYSQL_DATABASE" \
+    2>/dev/null
+}
+
+sql_quote() { printf '%s' "$1" | sed "s/'/''/g"; }
+
+# ── 3. 대상 사용자 찾기 ────────────────────────────────────────
+if [ -n "$USER_ID" ]; then
+  ROW=$(mysql_query "SELECT user_id, role, status FROM USERS WHERE user_id = ${USER_ID}") \
+    || die "DB 조회에 실패했습니다. ${ENV_FILE} 의 MySQL 접속 정보를 확인하세요."
+  [ -n "$ROW" ] || die "user_id=${USER_ID} 인 사용자가 없습니다."
+else
+  ROW=$(mysql_query "SELECT user_id, role, status FROM USERS
+                     WHERE oauth_provider = '$(sql_quote "$OAUTH_PROVIDER")'
+                       AND oauth_id = '$(sql_quote "$OAUTH_ID")'") \
+    || die "DB 조회에 실패했습니다. ${ENV_FILE} 의 MySQL 접속 정보를 확인하세요."
+  [ -n "$ROW" ] || die "목 사용자(${OAUTH_PROVIDER}/${OAUTH_ID})가 없습니다.
+       ${ENV_FILE} 에 MOCK_USER_SEED_ENABLED=true 를 넣고 ./run.sh restart 로 시드를 돌리세요."
+fi
+
+USER_ID=$(printf '%s' "$ROW" | cut -f1)
+ROLE=$(printf '%s' "$ROW" | cut -f2)
+STATUS=$(printf '%s' "$ROW" | cut -f3)
+[ "$STATUS" = "WITHDRAWN" ] && log "경고: 탈퇴 상태(WITHDRAWN)인 계정입니다. 인증 필터가 401 로 막습니다."
+
+# ── 4. JWT 서명 (서버 JwtProvider 와 같은 클레임 구성) ─────────
+b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+# jjwt 의 Keys.hmacShaKeyFor 는 시크릿 길이로 알고리즘을 고른다. 서버가 발급한 토큰과
+# 헤더까지 같아지도록 여기서도 같은 기준을 쓴다.
+SECRET_BYTES=$(printf '%s' "$JWT_SECRET" | wc -c | tr -d ' ')
+if   [ "$SECRET_BYTES" -ge 64 ]; then ALG="HS512"; DIGEST="-sha512"
+elif [ "$SECRET_BYTES" -ge 48 ]; then ALG="HS384"; DIGEST="-sha384"
+elif [ "$SECRET_BYTES" -ge 32 ]; then ALG="HS256"; DIGEST="-sha256"
+else die "JWT_SECRET 이 ${SECRET_BYTES}바이트입니다. HS256 최소 32바이트가 필요합니다."
+fi
+
+uuid() {
+  if command -v uuidgen >/dev/null; then
+    uuidgen
+  else
+    openssl rand -hex 16 | sed -E 's/(.{8})(.{4})(.{4})(.{4})(.{12})/\1-\2-\3-\4-\5/'
+  fi
+}
+
+sign() {
+  local payload="$1" header signing_input signature
+  header=$(printf '{"alg":"%s"}' "$ALG" | b64url)
+  signing_input="${header}.$(printf '%s' "$payload" | b64url)"
+  signature=$(printf '%s' "$signing_input" \
+    | openssl dgst -binary "$DIGEST" -hmac "$JWT_SECRET" | b64url)
+  printf '%s.%s' "$signing_input" "$signature"
+}
+
+NOW=$(date +%s)
+ACCESS_EXP=$(( NOW + ACCESS_EXPIRE_MS / 1000 ))
+REFRESH_EXP=$(( NOW + REFRESH_EXPIRE_MS / 1000 ))
+
+ACCESS_TOKEN=$(sign "{\"jti\":\"$(uuid)\",\"sub\":\"${USER_ID}\",\"role\":\"${ROLE}\",\"iat\":${NOW},\"exp\":${ACCESS_EXP}}")
+REFRESH_TOKEN=$(sign "{\"jti\":\"$(uuid)\",\"sub\":\"${USER_ID}\",\"role\":\"${ROLE}\",\"iat\":${NOW},\"exp\":${REFRESH_EXP}}")
+
+# ── 5. Refresh Token 을 DB 에 반영 (reissue 대조용) ────────────
+mysql_query "UPDATE USERS SET refresh_token = '${REFRESH_TOKEN}' WHERE user_id = ${USER_ID}" >/dev/null \
+  || die "USERS.refresh_token 갱신에 실패했습니다."
+
+# ── 6. 출력 ────────────────────────────────────────────────────
+case "$FORMAT" in
+  export)
+    echo "export ACCESS_TOKEN='${ACCESS_TOKEN}'"
+    echo "export REFRESH_TOKEN='${REFRESH_TOKEN}'"
+    ;;
+  json)
+    printf '{"userId":%s,"role":"%s","accessToken":"%s","refreshToken":"%s"}\n' \
+      "$USER_ID" "$ROLE" "$ACCESS_TOKEN" "$REFRESH_TOKEN"
+    ;;
+  *)
+    APP_PORT=$(read_env APP_PORT); APP_PORT="${APP_PORT:-8080}"
+    cat <<EOF
+[${SCRIPT_NAME}] userId=${USER_ID}, role=${ROLE}, status=${STATUS}, alg=${ALG}
+[${SCRIPT_NAME}] Access  (만료 $(( ACCESS_EXPIRE_MS / 60000 ))분)
+${ACCESS_TOKEN}
+
+[${SCRIPT_NAME}] Refresh (만료 $(( REFRESH_EXPIRE_MS / 86400000 ))일, USERS.refresh_token 에 반영됨)
+${REFRESH_TOKEN}
+
+[${SCRIPT_NAME}] 바로 써 보기
+  eval \$(./infra/scripts-local/seed/mock-token.sh --export)
+  curl -k -H "Authorization: Bearer \$ACCESS_TOKEN" https://localhost:${APP_PORT}/api/v1/home
+  curl -k -H "Authorization: Bearer \$ACCESS_TOKEN" https://localhost:${APP_PORT}/api/v1/letters
+EOF
+    ;;
+esac

--- a/src/main/java/com/dearjolly/server/domain/user/controller/AuthController.java
+++ b/src/main/java/com/dearjolly/server/domain/user/controller/AuthController.java
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -63,10 +62,9 @@ public class AuthController {
             @Parameter(description = "로그인 수단 (KAKAO, APPLE) - 대소문자를 가리지 않는다", required = true)
             @PathVariable OauthProvider provider
     ) {
-        String state = UUID.randomUUID().toString();
         return ResponseEntity
                 .status(FOUND)
-                .location(URI.create(authService.buildAuthorizationUri(provider, state)))
+                .location(URI.create(authService.buildAuthorizationUri(provider)))
                 .build();
     }
 
@@ -79,12 +77,13 @@ public class AuthController {
                     - 앱 진입 화면은 `termsAgreed == false` → 약관동의, `nicknameRegistered == false` → 닉네임, 둘 다 `true` → 홈이다.
                     - **토큰이 URL 에 실려 오므로** 받은 즉시 보안 저장소로 옮긴다.
                     - 로그인은 **기기 1대만 유지**된다. 탈퇴한 계정으로 다시 로그인하면 항상 신규 가입이다.
+                    - `state` 가 없거나 이 서버가 발급한 값이 아니거나 발급 후 10분이 지났으면 `AUTH_002` 다.
                     - 이 단계의 실패는 딥링크가 아니라 JSON 에러 응답으로 나간다.""")
     @ApiResponses({
             @ApiResponse(responseCode = "302", description = "앱 딥링크로 리다이렉트", content = @Content),
             @ApiResponse(
                     responseCode = "401",
-                    description = "`AUTH_002` 인가 코드 검증 실패",
+                    description = "`AUTH_002` state 검증 실패 · 인가 코드 검증 실패",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(
                     responseCode = "502",
@@ -95,9 +94,11 @@ public class AuthController {
     @GetMapping("/kakao/callback")
     public ResponseEntity<Void> kakaoCallback(
             @Parameter(description = "카카오가 발급한 인가 코드", required = true)
-            @RequestParam String code
+            @RequestParam String code,
+            @Parameter(description = "로그인 시작 때 서버가 붙여 보낸 state", required = true)
+            @RequestParam(required = false) String state
     ) {
-        return redirectToApp(authService.handleCallback(OauthProvider.KAKAO, code, null));
+        return redirectToApp(authService.handleCallback(OauthProvider.KAKAO, code, null, state));
     }
 
     @Operation(
@@ -106,12 +107,13 @@ public class AuthController {
                     **애플이 호출하는 주소다. 앱이 직접 호출하지 않는다.** 애플이 `form_post` 로 보내기 때문에 `POST` 다.
 
                     - 응답 형태와 앱 분기 규칙은 카카오 콜백과 같다.
-                    - 애플에서 이메일 제공을 거부한 유저는 이메일이 `null` 이다.""")
+                    - 애플에서 이메일 제공을 거부한 유저는 이메일이 `null` 이다.
+                    - `state` 가 없거나 이 서버가 발급한 값이 아니거나 발급 후 10분이 지났으면 `AUTH_002` 다.""")
     @ApiResponses({
             @ApiResponse(responseCode = "302", description = "앱 딥링크로 리다이렉트", content = @Content),
             @ApiResponse(
                     responseCode = "401",
-                    description = "`AUTH_002` 인가 코드 · id_token 검증 실패",
+                    description = "`AUTH_002` state 검증 실패 · 인가 코드 · id_token 검증 실패",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(
                     responseCode = "502",
@@ -124,9 +126,11 @@ public class AuthController {
             @Parameter(description = "애플이 발급한 인가 코드", required = true)
             @RequestParam String code,
             @Parameter(description = "애플이 함께 보내는 identity token", required = true)
-            @RequestParam(name = "id_token") String idToken
+            @RequestParam(name = "id_token") String idToken,
+            @Parameter(description = "로그인 시작 때 서버가 붙여 보낸 state", required = true)
+            @RequestParam(required = false) String state
     ) {
-        return redirectToApp(authService.handleCallback(OauthProvider.APPLE, code, idToken));
+        return redirectToApp(authService.handleCallback(OauthProvider.APPLE, code, idToken, state));
     }
 
     @Operation(

--- a/src/main/java/com/dearjolly/server/domain/user/service/AuthService.java
+++ b/src/main/java/com/dearjolly/server/domain/user/service/AuthService.java
@@ -11,6 +11,7 @@ import com.dearjolly.server.domain.user.repository.TermsAgreementRepository;
 import com.dearjolly.server.domain.user.repository.UserRepository;
 import com.dearjolly.server.global.auth.jwt.JwtProvider;
 import com.dearjolly.server.global.auth.oauth.OauthClientResolver;
+import com.dearjolly.server.global.auth.oauth.OauthStateProvider;
 import com.dearjolly.server.global.auth.oauth.OauthUserInfo;
 import com.dearjolly.server.global.exception.exception.BusinessException;
 import com.dearjolly.server.global.exception.response.ErrorCode;
@@ -29,14 +30,17 @@ public class AuthService {
     private final UserRepository userRepository;
     private final TermsAgreementRepository termsAgreementRepository;
     private final OauthClientResolver oauthClientResolver;
+    private final OauthStateProvider oauthStateProvider;
     private final JwtProvider jwtProvider;
 
-    public String buildAuthorizationUri(OauthProvider provider, String state) {
-        return oauthClientResolver.resolve(provider).buildAuthorizationUri(state);
+    public String buildAuthorizationUri(OauthProvider provider) {
+        return oauthClientResolver.resolve(provider).buildAuthorizationUri(oauthStateProvider.issue(provider));
     }
 
     @Transactional
-    public OauthLoginResult handleCallback(OauthProvider provider, String code, String idToken) {
+    public OauthLoginResult handleCallback(OauthProvider provider, String code, String idToken, String state) {
+        oauthStateProvider.validate(provider, state);
+
         OauthUserInfo userInfo = oauthClientResolver.resolve(provider).exchange(code, idToken);
 
         Optional<Users> found = userRepository.findByOauthProviderAndOauthId(

--- a/src/main/java/com/dearjolly/server/global/auth/oauth/OauthStateProvider.java
+++ b/src/main/java/com/dearjolly/server/global/auth/oauth/OauthStateProvider.java
@@ -1,0 +1,62 @@
+package com.dearjolly.server.global.auth.oauth;
+
+import com.dearjolly.server.domain.user.enums.OauthProvider;
+import com.dearjolly.server.global.auth.jwt.JwtProperties;
+import com.dearjolly.server.global.exception.exception.BusinessException;
+import com.dearjolly.server.global.exception.response.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+import javax.crypto.SecretKey;
+import org.springframework.stereotype.Component;
+
+// 서버가 여러 대로 뜨고 세션도 없으므로 state 를 저장해 두고 대조할 수 없다.
+// 대신 서명과 만료를 실어 보내, 콜백으로 돌아온 값이 이 서비스가 방금 발급한 것인지만 확인한다.
+@Component
+public class OauthStateProvider {
+    private static final long EXPIRE_MILLIS = 600_000L;
+
+    private final SecretKey key;
+
+    public OauthStateProvider(JwtProperties properties) {
+        this.key = Keys.hmacShaKeyFor(properties.secret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String issue(OauthProvider provider) {
+        Date now = new Date();
+        return Jwts.builder()
+                .id(UUID.randomUUID().toString())
+                .subject(provider.name())
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + EXPIRE_MILLIS))
+                .signWith(key)
+                .compact();
+    }
+
+    public void validate(OauthProvider provider, String state) {
+        if (state == null || state.isBlank()) {
+            throw new BusinessException(ErrorCode.OAUTH_AUTHENTICATION_FAILED, "state 누락");
+        }
+
+        Claims claims = parse(state);
+        if (!provider.name().equals(claims.getSubject())) {
+            throw new BusinessException(ErrorCode.OAUTH_AUTHENTICATION_FAILED, "state provider 불일치");
+        }
+    }
+
+    private Claims parse(String state) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(state)
+                    .getPayload();
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.OAUTH_AUTHENTICATION_FAILED, "state 검증 실패");
+        }
+    }
+}

--- a/src/main/java/com/dearjolly/server/global/seed/MockLetterSeed.java
+++ b/src/main/java/com/dearjolly/server/global/seed/MockLetterSeed.java
@@ -1,0 +1,26 @@
+package com.dearjolly.server.global.seed;
+
+import java.util.List;
+
+public record MockLetterSeed(
+        int daysAgo,
+        String content,
+        String correctedContent,
+        List<String> tips,
+        String stampName,
+        boolean read
+) {
+    public static MockLetterSeed completed(
+            int daysAgo, String content, String correctedContent, List<String> tips, String stampName, boolean read
+    ) {
+        return new MockLetterSeed(daysAgo, content, correctedContent, tips, stampName, read);
+    }
+
+    public static MockLetterSeed pending(int daysAgo, String content) {
+        return new MockLetterSeed(daysAgo, content, null, List.of(), null, false);
+    }
+
+    public boolean isFeedbackCompleted() {
+        return correctedContent != null;
+    }
+}

--- a/src/main/java/com/dearjolly/server/global/seed/MockUserSeedData.java
+++ b/src/main/java/com/dearjolly/server/global/seed/MockUserSeedData.java
@@ -1,0 +1,72 @@
+package com.dearjolly.server.global.seed;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class MockUserSeedData {
+    // 편지 본문은 시드 재실행 시 같은 편지인지 가리는 식별자로도 쓰인다. 본문을 고치면 새 편지가 하나 더 생긴다.
+    public static final List<MockLetterSeed> LETTERS = List.of(
+            MockLetterSeed.pending(
+                    0,
+                    "This morning I woke up late and ran to the station. "
+                            + "I almost miss the train but the driver waited a few seconds for me."
+            ),
+            MockLetterSeed.completed(
+                    1,
+                    "I stayed up late to watch a long movie, so I slept only four hours. "
+                            + "I feel so tired today and I could not focus at work.",
+                    "I stayed up late watching a long movie, so I slept only four hours. "
+                            + "I feel so tired today and I could not focus at work.",
+                    List.of(
+                            "stay up late 뒤에는 목적이 아니라 '무엇을 하며' 늦게까지 있었는지가 오니까 watching 처럼 -ing 형이 자연스러워요!",
+                            "could not focus 는 잘 쓰셨어요. 이어서 focus on my work 처럼 on 을 붙이면 더 또렷해져요!"
+                    ),
+                    "잠_침대_늦잠",
+                    false
+            ),
+            MockLetterSeed.completed(
+                    3,
+                    "I met my old friend at a ordinary cafe near my house. "
+                            + "We talk about our new jobs for almost two hours.",
+                    "I met my old friend at an ordinary cafe near my house. "
+                            + "We talked about our new jobs for almost two hours.",
+                    List.of(
+                            "a 와 an 은 뒤에 오는 소리로 정해져요. ordinary 는 모음 소리로 시작하니 an ordinary 가 맞아요!",
+                            "지난 일을 적을 때는 talk 가 아니라 talked 처럼 과거형으로 통일해 주세요!"
+                    ),
+                    "커피잔",
+                    true
+            ),
+            MockLetterSeed.completed(
+                    5,
+                    "I go running along the river this morning. "
+                            + "The air was very cold but it make me feel alive again.",
+                    "I went running along the river this morning. "
+                            + "The air was very cold but it made me feel alive again.",
+                    List.of(
+                            "this morning 처럼 이미 지나간 시간을 말할 때는 go 가 아니라 went 를 써요!",
+                            "한 문장 안에서 was 로 과거를 열었으면 뒤의 make 도 made 로 맞춰야 해요!",
+                            "feel alive 는 아주 좋은 표현이에요. 다음엔 feel alive again 처럼 부사를 붙여 보세요!"
+                    ),
+                    "달리기_런닝_운동",
+                    true
+            ),
+            MockLetterSeed.completed(
+                    8,
+                    "Yesterday was my birthday. My family got me a small cake which had only one candle on it.",
+                    "Yesterday was my birthday. My family got me a small cake that had only one candle on it.",
+                    List.of(
+                            "which 는 덧붙이는 정보에, that 은 앞말을 꼭 집어 한정할 때 써요. 여기서는 that 이 자연스러워요!"
+                    ),
+                    "케이크_생일",
+                    true
+            ),
+            MockLetterSeed.pending(
+                    12,
+                    "I tried to cook pasta by myself for the first time. "
+                            + "It was too salty but I eat all of it anyway."
+            )
+    );
+}

--- a/src/main/java/com/dearjolly/server/global/seed/MockUserSeedProperties.java
+++ b/src/main/java/com/dearjolly/server/global/seed/MockUserSeedProperties.java
@@ -1,0 +1,15 @@
+package com.dearjolly.server.global.seed;
+
+import com.dearjolly.server.domain.user.enums.OauthProvider;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+@ConfigurationProperties(prefix = "dearjolly.seed.mock-user")
+public record MockUserSeedProperties(
+        @DefaultValue("false") boolean enabled,
+        @DefaultValue("KAKAO") OauthProvider oauthProvider,
+        @DefaultValue("mock-user") String oauthId,
+        @DefaultValue("mock@dearjolly.local") String email,
+        @DefaultValue("jolly") String nickname
+) {
+}

--- a/src/main/java/com/dearjolly/server/global/seed/MockUserSeedResult.java
+++ b/src/main/java/com/dearjolly/server/global/seed/MockUserSeedResult.java
@@ -1,0 +1,4 @@
+package com.dearjolly.server.global.seed;
+
+public record MockUserSeedResult(Long userId, int createdLetters, int completedLetters) {
+}

--- a/src/main/java/com/dearjolly/server/global/seed/MockUserSeedWriter.java
+++ b/src/main/java/com/dearjolly/server/global/seed/MockUserSeedWriter.java
@@ -1,0 +1,157 @@
+package com.dearjolly.server.global.seed;
+
+import static com.dearjolly.server.domain.letter.constants.StampConstants.DEFAULT_STAMP_NAME;
+
+import com.dearjolly.server.domain.feedback.entity.CorrectionSegments;
+import com.dearjolly.server.domain.feedback.entity.FeedbackTips;
+import com.dearjolly.server.domain.feedback.entity.Feedbacks;
+import com.dearjolly.server.domain.feedback.service.CorrectionDiffer;
+import com.dearjolly.server.domain.feedback.service.CorrectionPair;
+import com.dearjolly.server.domain.letter.entity.Letters;
+import com.dearjolly.server.domain.letter.entity.Stamps;
+import com.dearjolly.server.domain.letter.repository.LetterRepository;
+import com.dearjolly.server.domain.letter.repository.StampRepository;
+import com.dearjolly.server.domain.user.entity.TermsAgreements;
+import com.dearjolly.server.domain.user.entity.Users;
+import com.dearjolly.server.domain.user.enums.TermsType;
+import com.dearjolly.server.domain.user.repository.TermsAgreementRepository;
+import com.dearjolly.server.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MockUserSeedWriter {
+    private static final String MODEL = "seed-mock";
+
+    private static final ZoneId SEED_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final UserRepository userRepository;
+    private final TermsAgreementRepository termsAgreementRepository;
+    private final LetterRepository letterRepository;
+    private final StampRepository stampRepository;
+    private final CorrectionDiffer correctionDiffer;
+
+    @Value("${dearjolly.terms.current-version}")
+    private String currentTermsVersion;
+
+    @Transactional
+    public MockUserSeedResult write(MockUserSeedProperties properties, List<MockLetterSeed> letterSeeds) {
+        Users user = findOrCreateUser(properties);
+        agreeAllTerms(user);
+
+        Set<String> written = user.getLetters().stream()
+                .map(Letters::getContent)
+                .collect(Collectors.toCollection(HashSet::new));
+        int created = 0;
+        int completed = 0;
+        for (MockLetterSeed seed : oldestFirst(letterSeeds)) {
+            if (!written.add(seed.content())) {
+                continue;
+            }
+            created++;
+            if (writeLetter(user, seed)) {
+                completed++;
+            }
+        }
+        return new MockUserSeedResult(user.getId(), created, completed);
+    }
+
+    // 탈퇴 API 를 시험하고 나면 같은 소셜 식별자가 탈퇴 계정에 묶여 있다. 실제 재가입과 같은 방식으로
+    // 식별자를 풀어 주고 새 계정을 만든다. 그래야 시드를 다시 돌리는 것만으로 테스트를 이어갈 수 있다.
+    private Users findOrCreateUser(MockUserSeedProperties properties) {
+        Optional<Users> found = userRepository.findByOauthProviderAndOauthId(
+                properties.oauthProvider(), properties.oauthId());
+
+        Users user = found.filter(existing -> !existing.isWithdrawn())
+                .orElseGet(() -> createUser(found.orElse(null), properties));
+        if (!user.isNicknameRegistered()) {
+            user.updateNickname(properties.nickname());
+        }
+        return user;
+    }
+
+    private Users createUser(Users withdrawnUser, MockUserSeedProperties properties) {
+        if (withdrawnUser != null) {
+            withdrawnUser.releaseOauthIdForRejoin();
+            userRepository.saveAndFlush(withdrawnUser);
+        }
+        return userRepository.save(
+                Users.create(properties.oauthProvider(), properties.oauthId(), properties.email())
+        );
+    }
+
+    private void agreeAllTerms(Users user) {
+        Set<TermsType> agreed = EnumSet.noneOf(TermsType.class);
+        termsAgreementRepository.findAllByUserIdOrderByAgreedAtDesc(user.getId())
+                .forEach(agreement -> agreed.add(agreement.getType()));
+
+        for (TermsType type : TermsType.values()) {
+            if (agreed.contains(type)) {
+                continue;
+            }
+            termsAgreementRepository.save(TermsAgreements.create(user, type, true, currentTermsVersion));
+        }
+    }
+
+    private List<MockLetterSeed> oldestFirst(List<MockLetterSeed> letterSeeds) {
+        return letterSeeds.stream()
+                .sorted(Comparator.comparingInt(MockLetterSeed::daysAgo).reversed())
+                .toList();
+    }
+
+    private boolean writeLetter(Users user, MockLetterSeed seed) {
+        LocalDate letterDate = LocalDate.now(SEED_ZONE).minusDays(seed.daysAgo());
+        Letters letter = letterRepository.save(
+                Letters.create(user, seed.content(), letterDate, SEED_ZONE, defaultStamp())
+        );
+        if (!seed.isFeedbackCompleted()) {
+            return false;
+        }
+        return completeFeedback(letter, seed);
+    }
+
+    // 편지 등록 API 와 같은 모양으로 "준비 중" 우표를 붙인다. 피드백까지 있는 편지는 곧바로 덮어쓴다.
+    private Stamps defaultStamp() {
+        return stampRepository.findByName(DEFAULT_STAMP_NAME).orElse(null);
+    }
+
+    private boolean completeFeedback(Letters letter, MockLetterSeed seed) {
+        Optional<Stamps> stamp = stampRepository.findByName(seed.stampName());
+        if (stamp.isEmpty()) {
+            log.warn("우표({})가 없어 편지를 제출 상태로 남긴다. 우표 시드를 먼저 확인한다.", seed.stampName());
+            return false;
+        }
+
+        List<CorrectionPair> pairs = correctionDiffer.diff(letter.getContent(), seed.correctedContent());
+        Feedbacks feedback = Feedbacks.create(letter, seed.correctedContent(), MODEL);
+        int sequence = 1;
+        for (CorrectionPair pair : pairs) {
+            CorrectionSegments.create(feedback, sequence++, pair.originalText(), pair.correctedText());
+        }
+        int sortOrder = 1;
+        for (String tip : seed.tips()) {
+            FeedbackTips.create(feedback, tip, sortOrder++);
+        }
+
+        letter.completeFeedback(stamp.get());
+        if (seed.read()) {
+            letter.markAsRead();
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/dearjolly/server/global/seed/MockUserSeeder.java
+++ b/src/main/java/com/dearjolly/server/global/seed/MockUserSeeder.java
@@ -1,0 +1,34 @@
+package com.dearjolly.server.global.seed;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Order(SeedOrder.MOCK_USER)
+@RequiredArgsConstructor
+public class MockUserSeeder implements ApplicationRunner {
+    private final MockUserSeedProperties mockUserSeedProperties;
+    private final MockUserSeedWriter mockUserSeedWriter;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (!mockUserSeedProperties.enabled()) {
+            log.info("목 사용자 시드가 비활성화되어 있어 건너뛴다.");
+            return;
+        }
+        try {
+            MockUserSeedResult result = mockUserSeedWriter.write(
+                    mockUserSeedProperties, MockUserSeedData.LETTERS);
+            log.info("목 사용자 시드 완료. userId={}, 편지 추가 {}건, 그중 피드백 완료 {}건",
+                    result.userId(), result.createdLetters(), result.completedLetters());
+        } catch (Exception e) {
+            // 우표 시드와 같은 이유로 기동은 막지 않는다. 테스트 데이터가 없다고 서버가 못 뜰 이유는 없다.
+            log.error("목 사용자 시드에 실패했다.", e);
+        }
+    }
+}

--- a/src/main/java/com/dearjolly/server/global/seed/SeedOrder.java
+++ b/src/main/java/com/dearjolly/server/global/seed/SeedOrder.java
@@ -1,0 +1,12 @@
+package com.dearjolly.server.global.seed;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SeedOrder {
+    // 목 사용자 편지는 완료 우표를 STAMPS 에서 찾아 붙이므로 우표 시드가 먼저 끝나 있어야 한다.
+    public static final int STAMP = 1;
+
+    public static final int MOCK_USER = 2;
+}

--- a/src/main/java/com/dearjolly/server/global/seed/StampSeeder.java
+++ b/src/main/java/com/dearjolly/server/global/seed/StampSeeder.java
@@ -15,12 +15,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@Order(SeedOrder.STAMP)
 @RequiredArgsConstructor
 public class StampSeeder implements ApplicationRunner {
     private static final String IMAGE_EXTENSION = ".png";

--- a/src/main/java/com/dearjolly/server/global/version/VersionProperties.java
+++ b/src/main/java/com/dearjolly/server/global/version/VersionProperties.java
@@ -2,6 +2,7 @@ package com.dearjolly.server.global.version;
 
 import com.dearjolly.server.global.version.enums.Platform;
 import java.util.Map;
+import java.util.function.Function;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** @param platforms 플랫폼별 재정의. 비어 있으면 공통 값을 그대로 쓴다. / */
@@ -9,6 +10,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record VersionProperties(
         String latest,
         String minSupported,
+        Boolean forceUpdate,
         String privacyPolicyUrl,
         String termsOfServiceUrl,
         String noticeUrl,
@@ -16,26 +18,38 @@ public record VersionProperties(
 ) {
     public record Override(
             String latest,
-            String minSupported
+            String minSupported,
+            Boolean forceUpdate
     ) {
     }
 
     public String latestFor(Platform platform) {
-        return resolve(platform, Override::latest, latest);
+        String value = override(platform, Override::latest);
+        return isBlank(value) ? latest : value;
     }
 
     public String minSupportedFor(Platform platform) {
-        return resolve(platform, Override::minSupported, minSupported);
+        String value = override(platform, Override::minSupported);
+        return isBlank(value) ? minSupported : value;
     }
 
-    private String resolve(Platform platform, java.util.function.Function<Override, String> field, String fallback) {
+    public boolean forceUpdateFor(Platform platform) {
+        Boolean value = override(platform, Override::forceUpdate);
+        if (value != null) {
+            return value;
+        }
+        return forceUpdate != null && forceUpdate;
+    }
+
+    private <T> T override(Platform platform, Function<Override, T> field) {
         if (platform == null || platforms == null) {
-            return fallback;
+            return null;
         }
-        Override override = platforms.get(platform);
-        if (override == null || field.apply(override) == null || field.apply(override).isBlank()) {
-            return fallback;
-        }
-        return field.apply(override);
+        Override found = platforms.get(platform);
+        return found == null ? null : field.apply(found);
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/src/main/java/com/dearjolly/server/global/version/dto/VersionGetResponse.java
+++ b/src/main/java/com/dearjolly/server/global/version/dto/VersionGetResponse.java
@@ -29,12 +29,10 @@ public record VersionGetResponse(
         String noticeUrl
 ) {
     public static VersionGetResponse of(VersionProperties properties, Platform platform) {
-        String latest = properties.latestFor(platform);
-        String minSupported = properties.minSupportedFor(platform);
         return new VersionGetResponse(
-                latest,
-                minSupported,
-                latest.equals(minSupported),
+                properties.latestFor(platform),
+                properties.minSupportedFor(platform),
+                properties.forceUpdateFor(platform),
                 properties.privacyPolicyUrl(),
                 properties.termsOfServiceUrl(),
                 properties.noticeUrl()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -67,6 +67,16 @@ dearjolly:
       location: classpath*:seed/stamps/*.png
       key-prefix: stamp/
 
+    # API 테스트용 목 사용자 시드. 약관 동의·닉네임까지 끝난 계정 하나와 편지 몇 통을 넣는다.
+    # 같은 소셜 식별자·같은 편지 본문은 다시 만들지 않으므로 재기동해도 데이터가 불어나지 않는다.
+    # 운영에 실제 계정처럼 보이는 행이 생기면 안 되므로 기본값은 꺼짐이다.
+    mock-user:
+      enabled: ${MOCK_USER_SEED_ENABLED:false}
+      oauth-provider: ${MOCK_USER_OAUTH_PROVIDER:KAKAO}
+      oauth-id: ${MOCK_USER_OAUTH_ID:mock-user}
+      email: ${MOCK_USER_EMAIL:mock@dearjolly.local}
+      nickname: ${MOCK_USER_NICKNAME:jolly}
+
   jwt:
     secret: ${JWT_SECRET}
     access-expire-millis: ${JWT_ACCESS_EXPIRE:1800000}      # 30분

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -80,9 +80,11 @@ dearjolly:
 
   # 앱 최소 지원 버전과 정책 페이지 URL.
   # platforms 아래 값을 채우면 그 플랫폼만 공통 값을 덮어쓴다.
+  # force-update 는 강제 업데이트 캠페인을 켜는 운영 스위치다. 서버는 앱 버전을 모르므로 두 버전 값에서 유추하지 않는다.
   version:
     latest: ${APP_LATEST_VERSION:1.0.0}
     min-supported: ${APP_MIN_SUPPORTED_VERSION:1.0.0}
+    force-update: ${APP_FORCE_UPDATE:false}
     privacy-policy-url: ${POLICY_PRIVACY_URL:https://dearjolly.com/privacy}
     terms-of-service-url: ${POLICY_TERMS_URL:https://dearjolly.com/terms}
     notice-url: ${POLICY_NOTICE_URL:https://dearjolly.com/notice}

--- a/src/test/java/com/dearjolly/server/domain/user/controller/AuthApiTest.java
+++ b/src/test/java/com/dearjolly/server/domain/user/controller/AuthApiTest.java
@@ -7,6 +7,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
 import com.dearjolly.server.domain.user.entity.Users;
+import com.dearjolly.server.domain.user.enums.OauthProvider;
+import com.dearjolly.server.global.auth.oauth.OauthStateProvider;
 import com.dearjolly.server.support.ApiTestSupport;
 import io.restassured.http.ContentType;
 import java.util.Map;
@@ -14,10 +16,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
 class AuthApiTest extends ApiTestSupport {
+    @Autowired
+    private OauthStateProvider oauthStateProvider;
+
     @DisplayName("GET /api/v1/auth/{provider} : 카카오 로그인 페이지로 302 리다이렉트한다")
     @Test
     void authorizeKakao() {
@@ -26,7 +32,8 @@ class AuthApiTest extends ApiTestSupport {
                 .then()
                 .statusCode(HttpStatus.FOUND.value())
                 .header(HttpHeaders.LOCATION, containsString("kauth.kakao.com/oauth/authorize"))
-                .header(HttpHeaders.LOCATION, containsString("response_type=code"));
+                .header(HttpHeaders.LOCATION, containsString("response_type=code"))
+                .header(HttpHeaders.LOCATION, containsString("state="));
     }
 
     @DisplayName("GET /api/v1/auth/{provider} : 애플은 form_post 로 콜백받도록 요청한다")
@@ -59,6 +66,54 @@ class AuthApiTest extends ApiTestSupport {
                 .then()
                 .statusCode(HttpStatus.BAD_REQUEST.value())
                 .body("code", equalTo("COMMON_001"));
+    }
+
+    @DisplayName("GET /api/v1/auth/kakao/callback : state 가 없으면 AUTH_002")
+    @Test
+    void kakaoCallbackWithoutState() {
+        given().redirects().follow(false)
+                .queryParam("code", "any-code")
+                .when().get("/api/v1/auth/kakao/callback")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .body("code", equalTo("AUTH_002"));
+    }
+
+    @DisplayName("GET /api/v1/auth/kakao/callback : 서버가 발급하지 않은 state 면 AUTH_002")
+    @Test
+    void kakaoCallbackWithForgedState() {
+        given().redirects().follow(false)
+                .queryParam("code", "any-code")
+                .queryParam("state", "forged-state")
+                .when().get("/api/v1/auth/kakao/callback")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .body("code", equalTo("AUTH_002"));
+    }
+
+    @DisplayName("GET /api/v1/auth/kakao/callback : 다른 provider 로 발급한 state 면 AUTH_002")
+    @Test
+    void kakaoCallbackWithOtherProviderState() {
+        given().redirects().follow(false)
+                .queryParam("code", "any-code")
+                .queryParam("state", oauthStateProvider.issue(OauthProvider.APPLE))
+                .when().get("/api/v1/auth/kakao/callback")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .body("code", equalTo("AUTH_002"));
+    }
+
+    @DisplayName("POST /api/v1/auth/apple/callback : state 가 없으면 AUTH_002")
+    @Test
+    void appleCallbackWithoutState() {
+        given().redirects().follow(false)
+                .contentType(ContentType.URLENC)
+                .formParam("code", "any-code")
+                .formParam("id_token", "any-id-token")
+                .when().post("/api/v1/auth/apple/callback")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .body("code", equalTo("AUTH_002"));
     }
 
     @DisplayName("POST /api/v1/auth/reissue : 토큰 재발급 API - 회전된 값이 저장된다")

--- a/src/test/java/com/dearjolly/server/global/seed/MockUserSeedDataTest.java
+++ b/src/test/java/com/dearjolly/server/global/seed/MockUserSeedDataTest.java
@@ -1,0 +1,77 @@
+package com.dearjolly.server.global.seed;
+
+import static com.dearjolly.server.domain.feedback.entity.Feedbacks.MAX_TIP_COUNT;
+import static com.dearjolly.server.domain.letter.constants.LetterValidationConstants.CONTENT_MAX_LENGTH;
+import static com.dearjolly.server.domain.letter.constants.LetterValidationConstants.KOREAN_PATTERN;
+import static com.dearjolly.server.domain.letter.constants.StampConstants.DEFAULT_STAMP_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+// 시드 데이터가 편지 작성 API 의 제약을 그대로 만족하는지 본다.
+// 어긋나면 시드가 API 로는 만들 수 없는 편지를 DB 에 넣어 테스트를 헛돌게 한다.
+class MockUserSeedDataTest {
+    @DisplayName("편지 본문은 서로 달라야 시드를 다시 돌려도 늘어나지 않는다.")
+    @Test
+    void contentsAreUnique() {
+        // when
+        Set<String> contents = MockUserSeedData.LETTERS.stream()
+                .map(MockLetterSeed::content)
+                .collect(Collectors.toSet());
+
+        // then
+        assertThat(contents).hasSameSizeAs(MockUserSeedData.LETTERS);
+    }
+
+    @DisplayName("편지 본문은 편지 작성 API 의 길이·영문 제약을 지킨다.")
+    @Test
+    void contentsSatisfyLetterConstraints() {
+        // when & then
+        assertThat(MockUserSeedData.LETTERS).allSatisfy(seed -> {
+            assertThat(seed.content()).isNotBlank();
+            assertThat(seed.content().codePointCount(0, seed.content().length()))
+                    .isLessThanOrEqualTo(CONTENT_MAX_LENGTH);
+            assertThat(KOREAN_PATTERN.matcher(seed.content()).find()).isFalse();
+        });
+    }
+
+    @DisplayName("피드백이 붙은 편지의 학습 팁은 최대 개수를 넘지 않는다.")
+    @Test
+    void tipsAreWithinLimit() {
+        // when & then
+        assertThat(MockUserSeedData.LETTERS)
+                .filteredOn(MockLetterSeed::isFeedbackCompleted)
+                .allSatisfy(seed -> assertThat(seed.tips()).isNotEmpty().hasSizeLessThanOrEqualTo(MAX_TIP_COUNT));
+    }
+
+    @DisplayName("피드백이 붙은 편지의 우표는 우표 시드 이미지에 실제로 존재한다.")
+    @Test
+    void stampNamesExistInStampSeed() throws IOException {
+        // given
+        Set<String> seededStampNames = seededStampNames();
+
+        // when & then
+        assertThat(MockUserSeedData.LETTERS)
+                .filteredOn(MockLetterSeed::isFeedbackCompleted)
+                .allSatisfy(seed -> assertThat(seed.stampName())
+                        .isNotEqualTo(DEFAULT_STAMP_NAME)
+                        .isIn(seededStampNames));
+    }
+
+    private Set<String> seededStampNames() throws IOException {
+        Resource[] resources = new PathMatchingResourcePatternResolver()
+                .getResources("classpath*:seed/stamps/*.png");
+        return Arrays.stream(resources)
+                .map(Resource::getFilename)
+                .filter(fileName -> fileName != null)
+                .map(fileName -> fileName.substring(0, fileName.lastIndexOf('.')))
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/com/dearjolly/server/global/seed/MockUserSeedWriterTest.java
+++ b/src/test/java/com/dearjolly/server/global/seed/MockUserSeedWriterTest.java
@@ -1,0 +1,212 @@
+package com.dearjolly.server.global.seed;
+
+import static com.dearjolly.server.domain.letter.enums.Status.FEEDBACK_COMPLETED;
+import static com.dearjolly.server.domain.letter.enums.Status.SUBMITTED;
+import static com.dearjolly.server.domain.user.enums.OauthProvider.KAKAO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.dearjolly.server.domain.feedback.service.CorrectionDiffer;
+import com.dearjolly.server.domain.letter.entity.Letters;
+import com.dearjolly.server.domain.letter.entity.Stamps;
+import com.dearjolly.server.domain.letter.repository.LetterRepository;
+import com.dearjolly.server.domain.letter.repository.StampRepository;
+import com.dearjolly.server.domain.user.entity.TermsAgreements;
+import com.dearjolly.server.domain.user.entity.Users;
+import com.dearjolly.server.domain.user.enums.TermsType;
+import com.dearjolly.server.domain.user.repository.TermsAgreementRepository;
+import com.dearjolly.server.domain.user.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MockUserSeedWriterTest {
+    private static final String OAUTH_ID = "mock-user";
+    private static final String NICKNAME = "jolly";
+    private static final String STAMP_NAME = "커피잔";
+
+    private static final MockLetterSeed COMPLETED_SEED = MockLetterSeed.completed(
+            1,
+            "I go running along the river.",
+            "I went running along the river.",
+            List.of("과거형으로 맞춰 주세요!"),
+            STAMP_NAME,
+            true
+    );
+
+    private static final MockLetterSeed PENDING_SEED = MockLetterSeed.pending(
+            0, "I almost miss the train this morning."
+    );
+
+    private static final List<MockLetterSeed> SEEDS = List.of(COMPLETED_SEED, PENDING_SEED);
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TermsAgreementRepository termsAgreementRepository;
+
+    @Mock
+    private LetterRepository letterRepository;
+
+    @Mock
+    private StampRepository stampRepository;
+
+    private MockUserSeedWriter mockUserSeedWriter;
+
+    @BeforeEach
+    void setUp() {
+        mockUserSeedWriter = new MockUserSeedWriter(
+                userRepository, termsAgreementRepository, letterRepository, stampRepository, new CorrectionDiffer()
+        );
+        ReflectionTestUtils.setField(mockUserSeedWriter, "currentTermsVersion", "1.0.0");
+
+        given(letterRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(termsAgreementRepository.findAllByUserIdOrderByAgreedAtDesc(anyLong())).willReturn(List.of());
+        given(stampRepository.findByName(anyString())).willReturn(Optional.of(stamp()));
+    }
+
+    @DisplayName("목 사용자가 없으면 계정·약관 동의·편지를 한 번에 만든다.")
+    @Test
+    void write() {
+        // given
+        given(userRepository.findByOauthProviderAndOauthId(KAKAO, OAUTH_ID)).willReturn(Optional.empty());
+        Users saved = persistedUser();
+        given(userRepository.save(any())).willReturn(saved);
+
+        // when
+        MockUserSeedResult result = mockUserSeedWriter.write(properties(), SEEDS);
+
+        // then
+        assertThat(result.userId()).isEqualTo(1L);
+        assertThat(result.createdLetters()).isEqualTo(2);
+        assertThat(result.completedLetters()).isEqualTo(1);
+        assertThat(saved.getNickname()).isEqualTo(NICKNAME);
+        verify(termsAgreementRepository, times(TermsType.values().length)).save(any());
+    }
+
+    @DisplayName("같은 본문의 편지가 이미 있으면 다시 만들지 않는다.")
+    @Test
+    void writeIsIdempotent() {
+        // given
+        Users existing = persistedUser();
+        existing.updateNickname(NICKNAME);
+        given(userRepository.findByOauthProviderAndOauthId(KAKAO, OAUTH_ID)).willReturn(Optional.of(existing));
+        mockUserSeedWriter.write(properties(), SEEDS);
+
+        // when
+        MockUserSeedResult result = mockUserSeedWriter.write(properties(), SEEDS);
+
+        // then
+        assertThat(result.createdLetters()).isZero();
+        assertThat(existing.getLetters()).hasSize(SEEDS.size());
+        verify(letterRepository, times(SEEDS.size())).save(any());
+    }
+
+    @DisplayName("편지 본문에 맞는 우표가 없으면 피드백을 붙이지 않고 제출 상태로 남긴다.")
+    @Test
+    void writeWithoutStamp() {
+        // given
+        given(userRepository.findByOauthProviderAndOauthId(KAKAO, OAUTH_ID)).willReturn(Optional.empty());
+        Users saved = persistedUser();
+        given(userRepository.save(any())).willReturn(saved);
+        given(stampRepository.findByName(anyString())).willReturn(Optional.empty());
+
+        // when
+        MockUserSeedResult result = mockUserSeedWriter.write(properties(), SEEDS);
+
+        // then
+        assertThat(result.completedLetters()).isZero();
+        assertThat(saved.getLetters()).extracting(Letters::getStatus).containsOnly(SUBMITTED);
+    }
+
+    @DisplayName("피드백이 있는 편지는 완료 상태·읽음 처리까지 끝난 채로 들어간다.")
+    @Test
+    void writeCompletedLetter() {
+        // given
+        given(userRepository.findByOauthProviderAndOauthId(KAKAO, OAUTH_ID)).willReturn(Optional.empty());
+        Users saved = persistedUser();
+        given(userRepository.save(any())).willReturn(saved);
+
+        // when
+        mockUserSeedWriter.write(properties(), List.of(COMPLETED_SEED));
+
+        // then
+        Letters letter = saved.getLetters().getFirst();
+        assertThat(letter.getStatus()).isEqualTo(FEEDBACK_COMPLETED);
+        assertThat(letter.isRead()).isTrue();
+        assertThat(letter.getStamp().getName()).isEqualTo(STAMP_NAME);
+        assertThat(letter.getFeedback().getCorrectedContent()).isEqualTo(COMPLETED_SEED.correctedContent());
+        assertThat(letter.getFeedback().getTips()).hasSize(COMPLETED_SEED.tips().size());
+    }
+
+    @DisplayName("탈퇴한 목 사용자가 남아 있으면 소셜 식별자를 풀고 계정을 다시 만든다.")
+    @Test
+    void writeAfterWithdrawal() {
+        // given
+        Users withdrawn = persistedUser();
+        withdrawn.withdraw();
+        given(userRepository.findByOauthProviderAndOauthId(KAKAO, OAUTH_ID)).willReturn(Optional.of(withdrawn));
+        Users rejoined = persistedUser();
+        given(userRepository.save(any())).willReturn(rejoined);
+
+        // when
+        MockUserSeedResult result = mockUserSeedWriter.write(properties(), SEEDS);
+
+        // then
+        verify(userRepository).saveAndFlush(withdrawn);
+        assertThat(withdrawn.getOauthId()).startsWith(OAUTH_ID).isNotEqualTo(OAUTH_ID);
+        assertThat(result.createdLetters()).isEqualTo(SEEDS.size());
+    }
+
+    @DisplayName("이미 동의한 약관은 다시 남기지 않는다.")
+    @Test
+    void writeSkipsAgreedTerms() {
+        // given
+        Users existing = persistedUser();
+        given(userRepository.findByOauthProviderAndOauthId(KAKAO, OAUTH_ID)).willReturn(Optional.of(existing));
+        given(termsAgreementRepository.findAllByUserIdOrderByAgreedAtDesc(anyLong()))
+                .willReturn(List.of(agreement(existing, TermsType.SERVICE)));
+
+        // when
+        mockUserSeedWriter.write(properties(), List.of());
+
+        // then
+        verify(termsAgreementRepository, times(TermsType.values().length - 1)).save(any());
+        verify(letterRepository, never()).save(any());
+    }
+
+    private MockUserSeedProperties properties() {
+        return new MockUserSeedProperties(true, KAKAO, OAUTH_ID, "mock@dearjolly.local", NICKNAME);
+    }
+
+    private Users persistedUser() {
+        Users user = Users.create(KAKAO, OAUTH_ID, "mock@dearjolly.local");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        return user;
+    }
+
+    private TermsAgreements agreement(Users user, TermsType type) {
+        return TermsAgreements.create(user, type, true, "1.0.0");
+    }
+
+    private Stamps stamp() {
+        return Stamps.create(STAMP_NAME, "stamp/커피잔.png");
+    }
+}

--- a/src/test/java/com/dearjolly/server/global/seed/MockUserSeederTest.java
+++ b/src/test/java/com/dearjolly/server/global/seed/MockUserSeederTest.java
@@ -1,0 +1,63 @@
+package com.dearjolly.server.global.seed;
+
+import static com.dearjolly.server.domain.user.enums.OauthProvider.KAKAO;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+
+@ExtendWith(MockitoExtension.class)
+class MockUserSeederTest {
+    @Mock
+    private MockUserSeedWriter mockUserSeedWriter;
+
+    @DisplayName("시드가 켜져 있으면 목 사용자 시드 데이터를 그대로 넘긴다.")
+    @Test
+    void seed() {
+        // given
+        given(mockUserSeedWriter.write(any(), any())).willReturn(new MockUserSeedResult(1L, 6, 4));
+
+        // when
+        seeder(true).run(new DefaultApplicationArguments());
+
+        // then
+        verify(mockUserSeedWriter).write(properties(true), MockUserSeedData.LETTERS);
+    }
+
+    @DisplayName("시드가 비활성화되어 있으면 DB 를 건드리지 않는다.")
+    @Test
+    void seedDisabled() {
+        // when
+        seeder(false).run(new DefaultApplicationArguments());
+
+        // then
+        verifyNoInteractions(mockUserSeedWriter);
+    }
+
+    @DisplayName("시드가 실패해도 예외를 밖으로 던지지 않아 기동을 막지 않는다.")
+    @Test
+    void seedSwallowsFailure() {
+        // given
+        given(mockUserSeedWriter.write(any(), any())).willThrow(new IllegalStateException("boom"));
+
+        // when & then
+        assertThatCode(() -> seeder(true).run(new DefaultApplicationArguments()))
+                .doesNotThrowAnyException();
+    }
+
+    private MockUserSeeder seeder(boolean enabled) {
+        return new MockUserSeeder(properties(enabled), mockUserSeedWriter);
+    }
+
+    private MockUserSeedProperties properties(boolean enabled) {
+        return new MockUserSeedProperties(enabled, KAKAO, "mock-user", "mock@dearjolly.local", "jolly");
+    }
+}

--- a/src/test/java/com/dearjolly/server/global/version/controller/VersionApiTest.java
+++ b/src/test/java/com/dearjolly/server/global/version/controller/VersionApiTest.java
@@ -32,7 +32,8 @@ class VersionApiTest extends ApiTestSupport {
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .body("latestVersion", equalTo("1.2.0"))
-                .body("minSupportedVersion", equalTo("1.1.0"));
+                .body("minSupportedVersion", equalTo("1.1.0"))
+                .body("forceUpdate", equalTo(true));
     }
 
     @DisplayName("GET /api/v1/version : 재정의가 없는 플랫폼은 공통 값을 그대로 받는다")
@@ -42,7 +43,8 @@ class VersionApiTest extends ApiTestSupport {
                 .when().get("/api/v1/version")
                 .then()
                 .statusCode(HttpStatus.OK.value())
-                .body("minSupportedVersion", equalTo("1.0.0"));
+                .body("minSupportedVersion", equalTo("1.0.0"))
+                .body("forceUpdate", equalTo(false));
     }
 
     @DisplayName("GET /api/v1/version : 알 수 없는 platform 은 COMMON_001")

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -34,12 +34,14 @@ dearjolly:
   version:
     latest: 1.2.0
     min-supported: 1.0.0
+    force-update: false
     privacy-policy-url: https://dearjolly.com/privacy
     terms-of-service-url: https://dearjolly.com/terms
     notice-url: https://dearjolly.com/notice
     platforms:
       IOS:
         min-supported: 1.1.0
+        force-update: true
   oauth:
     app-redirect-uri: dearjolly://auth/callback
     kakao:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -22,6 +22,9 @@ dearjolly:
   seed:
     stamp:
       enabled: false
+    # 통합 테스트는 각자 필요한 데이터만 만든다. 시드가 끼면 개수 검증이 어긋난다.
+    mock-user:
+      enabled: false
 
   jwt:
     secret: test-jwt-secret-key-for-integration-tests-32bytes+


### PR DESCRIPTION
## 📣 Related Issue
- close #

## 📝 Key Changes
- API 테스트용 목 사용자 시드 추가 (약관 동의·닉네임 등록까지 끝난 계정 1명 + 편지 6통). 자연키 기반이라 재기동해도 데이터가 불어나지 않고, **기본값은 꺼짐**이라 운영에는 들어가지 않는다
- 목 사용자 토큰을 로컬에서 발급하는 스크립트 추가 (`infra/scripts-local/seed/mock-token.sh`)
- 시드 데이터 컨벤션을 `seed-data` 스킬로 정리하고 README·RUN.md·ERD.md 갱신
- 소셜 로그인 콜백에서 `state` 검증
- 버전 응답의 `forceUpdate` 를 설정값으로 내려주도록 수정
- 운영 서버 실제 동작에 맞게 API 명세 보정

## To Reviewers
- 목 사용자 시드는 `MOCK_USER_SEED_ENABLED` 기본값이 `false` 이고 `.env.local.example` 에서만 켭니다. `.env.prod.example` 에는 키를 넣지 않았으니, 운영 env 에 이 키가 새어 들어가지 않는지만 봐주세요.
- 토큰 발급은 서버에 엔드포인트를 만들지 않고 `.env.local` 의 `JWT_SECRET` 으로 로컬에서 직접 서명합니다. 테스트 편의로 뚫은 인증 우회가 운영까지 따라가지 않게 하려는 의도입니다.
- 편지 본문이 시드 멱등성 키라, `MockUserSeedData` 의 본문을 고치면 기존 편지가 남고 새 편지가 하나 더 생깁니다.