### PR TITLE
[REFACTOR] N+1 문제 및 쿼리 개선

### DIFF
--- a/src/main/java/com/dearjolly/server/domain/letter/repository/LetterRepository.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/repository/LetterRepository.java
@@ -2,14 +2,21 @@ package com.dearjolly.server.domain.letter.repository;
 
 import com.dearjolly.server.domain.letter.entity.Letters;
 import com.dearjolly.server.domain.letter.enums.Status;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LetterRepository extends JpaRepository<Letters, Long> {
     Optional<Letters> findFirstByUserIdOrderByIdDesc(Long userId);
+
+    // 시드는 어떤 편지가 이미 있는지만 보면 된다. 엔티티를 읽으면 편지마다 피드백 조회가 딸려 나온다.
+    @Query("SELECT l.content FROM Letters l WHERE l.user.id = :userId")
+    List<String> findAllContentByUserId(@Param("userId") Long userId);
 
     @EntityGraph(attributePaths = {"stamp", "feedback"})
     Optional<Letters> findByIdAndUserId(Long id, Long userId);

--- a/src/main/java/com/dearjolly/server/domain/letter/repository/LetterRepository.java
+++ b/src/main/java/com/dearjolly/server/domain/letter/repository/LetterRepository.java
@@ -14,7 +14,9 @@ public interface LetterRepository extends JpaRepository<Letters, Long> {
     @EntityGraph(attributePaths = {"stamp", "feedback"})
     Optional<Letters> findByIdAndUserId(Long id, Long userId);
 
-    @EntityGraph(attributePaths = "stamp")
+    // feedback 을 함께 가져오지 않으면 편지마다 조회가 한 번씩 더 나간다.
+    // 비소유 측 @OneToOne 은 프록시를 만들 수 없어, Hibernate 가 null 여부를 알려고 행마다 쿼리를 날린다.
+    @EntityGraph(attributePaths = {"stamp", "feedback"})
     Slice<Letters> findAllByUserId(Long userId, Pageable pageable);
 
     long countByUserIdAndStatus(Long userId, Status status);

--- a/src/main/java/com/dearjolly/server/domain/user/service/OnboardingChecker.java
+++ b/src/main/java/com/dearjolly/server/domain/user/service/OnboardingChecker.java
@@ -1,5 +1,7 @@
 package com.dearjolly.server.domain.user.service;
 
+import com.dearjolly.server.domain.user.entity.Users;
+
 public interface OnboardingChecker {
-    boolean isOnboardingCompleted(Long userId);
+    boolean isOnboardingCompleted(Users user);
 }

--- a/src/main/java/com/dearjolly/server/domain/user/service/UserService.java
+++ b/src/main/java/com/dearjolly/server/domain/user/service/UserService.java
@@ -82,11 +82,9 @@ public class UserService implements OnboardingChecker {
     }
 
     @Override
-    public boolean isOnboardingCompleted(Long userId) {
-        Users user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    public boolean isOnboardingCompleted(Users user) {
         return user.isNicknameRegistered()
-                && TermsAgreementReader.isRequiredTermsAgreed(currentTermsState(userId));
+                && TermsAgreementReader.isRequiredTermsAgreed(currentTermsState(user.getId()));
     }
 
     private Users findActiveUser(Long userId) {

--- a/src/main/java/com/dearjolly/server/domain/user/service/WithdrawnUserCleanupScheduler.java
+++ b/src/main/java/com/dearjolly/server/domain/user/service/WithdrawnUserCleanupScheduler.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class WithdrawnUserCleanupScheduler {
     private final UserRepository userRepository;
+    private final WithdrawnUserPurger withdrawnUserPurger;
 
     @Value("${dearjolly.withdrawal.retention-days}")
     private int retentionDays;
@@ -28,7 +29,7 @@ public class WithdrawnUserCleanupScheduler {
         if (expired.isEmpty()) {
             return;
         }
-        userRepository.deleteAll(expired);
+        withdrawnUserPurger.purge(expired.stream().map(Users::getId).toList());
         log.info("유예기간이 지난 탈퇴 계정 {}건을 삭제했다. threshold={}", expired.size(), threshold);
     }
 }

--- a/src/main/java/com/dearjolly/server/domain/user/service/WithdrawnUserPurger.java
+++ b/src/main/java/com/dearjolly/server/domain/user/service/WithdrawnUserPurger.java
@@ -1,0 +1,58 @@
+package com.dearjolly.server.domain.user.service;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 유예기간이 지난 탈퇴 계정과 그 하위 데이터를 한 번에 지운다.
+ * <p>
+ * 엔티티 cascade 에 맡기면 계정마다 편지 · 약관 컬렉션을 읽어 한 행씩 지우므로,
+ * 쿼리가 계정 수 × 편지 수만큼 늘어난다. 자식부터 부모 순서로 벌크 삭제한다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class WithdrawnUserPurger {
+    // 외래키를 참조하는 쪽부터 지운다. 순서를 바꾸면 제약조건에 걸린다.
+    private static final List<String> DELETE_QUERIES = List.of(
+            """
+            DELETE FROM FeedbackTips t
+            WHERE t.feedback.id IN (
+                SELECT f.id FROM Feedbacks f
+                WHERE f.letter.id IN (SELECT l.id FROM Letters l WHERE l.user.id IN :userIds))
+            """,
+            """
+            DELETE FROM CorrectionSegments s
+            WHERE s.feedback.id IN (
+                SELECT f.id FROM Feedbacks f
+                WHERE f.letter.id IN (SELECT l.id FROM Letters l WHERE l.user.id IN :userIds))
+            """,
+            """
+            DELETE FROM Feedbacks f
+            WHERE f.letter.id IN (SELECT l.id FROM Letters l WHERE l.user.id IN :userIds)
+            """,
+            "DELETE FROM Letters l WHERE l.user.id IN :userIds",
+            "DELETE FROM TermsAgreements a WHERE a.user.id IN :userIds",
+            "DELETE FROM Users u WHERE u.id IN :userIds"
+    );
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Transactional
+    public void purge(List<Long> userIds) {
+        if (userIds.isEmpty()) {
+            return;
+        }
+        for (String query : DELETE_QUERIES) {
+            entityManager.createQuery(query)
+                    .setParameter("userIds", userIds)
+                    .executeUpdate();
+        }
+        // 벌크 삭제는 영속성 컨텍스트를 거치지 않는다. 이미 올라와 있는 엔티티를 비워
+        // 지워진 행을 살아 있는 것으로 착각하지 않게 한다.
+        entityManager.clear();
+    }
+}

--- a/src/main/java/com/dearjolly/server/global/admin/controller/AdminController.java
+++ b/src/main/java/com/dearjolly/server/global/admin/controller/AdminController.java
@@ -31,10 +31,11 @@ public class AdminController {
     @Operation(
             summary = "관리자 로그인",
             description = """
-                    - 아이디와 비밀번호로 **관리자 Access Token** 을 받는다. 회원가입 API 는 없다.
-                    - 계정은 서버 설정값 하나뿐이며, 앱 사용자 계정과 별개다.
-                    - 발급된 토큰은 `PATCH /api/v1/admin/version` 같은 관리자 전용 API 에서 쓴다.
-                    - **Refresh Token 은 없다.** 만료되면 다시 로그인한다.""")
+                    - 아이디와 비밀번호로 로그인해 **소셜 로그인과 똑같은 토큰 한 쌍**을 받는다.
+                    - **회원가입 API 는 없다.** 관리자 계정은 서버가 미리 만들어 둔 것 하나뿐이고, 이 API 는 로그인만 한다.
+                    - 관리자도 **일반 사용자와 똑같은 계정**이라, 이 토큰으로 편지 · 홈 · 계정 API 를 그대로 호출할 수 있다.
+                    - 발급된 토큰은 `PATCH /api/v1/admin/version` 같은 관리자 전용 API 에도 쓴다.
+                    - `refreshToken` 은 `POST /api/v1/auth/reissue` 에 그대로 쓴다.""")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
             @ApiResponse(

--- a/src/main/java/com/dearjolly/server/global/auth/interceptor/OnboardingInterceptor.java
+++ b/src/main/java/com/dearjolly/server/global/auth/interceptor/OnboardingInterceptor.java
@@ -1,14 +1,13 @@
 package com.dearjolly.server.global.auth.interceptor;
 
+import com.dearjolly.server.domain.user.entity.Users;
 import com.dearjolly.server.domain.user.service.OnboardingChecker;
-import com.dearjolly.server.global.auth.principal.AuthUser;
+import com.dearjolly.server.global.auth.principal.AuthenticatedUserHolder;
 import com.dearjolly.server.global.exception.exception.BusinessException;
 import com.dearjolly.server.global.exception.response.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -16,14 +15,15 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @RequiredArgsConstructor
 public class OnboardingInterceptor implements HandlerInterceptor {
     private final OnboardingChecker onboardingChecker;
+    private final AuthenticatedUserHolder authenticatedUserHolder;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !(authentication.getPrincipal() instanceof AuthUser authUser)) {
+        Users user = authenticatedUserHolder.get();
+        if (user == null) {
             throw new BusinessException(ErrorCode.ACCESS_TOKEN_INVALID);
         }
-        if (!onboardingChecker.isOnboardingCompleted(authUser.userId())) {
+        if (!onboardingChecker.isOnboardingCompleted(user)) {
             throw new BusinessException(ErrorCode.ONBOARDING_NOT_COMPLETED);
         }
         return true;

--- a/src/main/java/com/dearjolly/server/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dearjolly/server/global/auth/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.dearjolly.server.global.auth.jwt;
 import com.dearjolly.server.domain.user.entity.Users;
 import com.dearjolly.server.domain.user.repository.UserRepository;
 import com.dearjolly.server.global.auth.principal.AuthUser;
+import com.dearjolly.server.global.auth.principal.AuthenticatedUserHolder;
 import com.dearjolly.server.global.exception.response.ErrorCode;
 import com.dearjolly.server.global.exception.response.ErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,6 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
+    private final AuthenticatedUserHolder authenticatedUserHolder;
     private final ObjectMapper objectMapper;
     private final List<String> skipPathPatterns;
 
@@ -72,6 +74,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
+        authenticatedUserHolder.set(user);
         authenticate(new AuthUser(user.getId(), user.getRole()));
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/dearjolly/server/global/auth/principal/AuthenticatedUserHolder.java
+++ b/src/main/java/com/dearjolly/server/global/auth/principal/AuthenticatedUserHolder.java
@@ -1,0 +1,25 @@
+package com.dearjolly.server.global.auth.principal;
+
+import com.dearjolly.server.domain.user.entity.Users;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+/**
+ * 인증 필터가 조회한 사용자를 같은 요청 안에서 다시 쓰기 위해 담아 둔다.
+ * <p>
+ * 온보딩 가드가 같은 사용자를 한 번 더 조회하면 편지 · 홈 API 마다 조회가 두 번씩 나간다.
+ * 담기는 시점이 트랜잭션 밖이라 지연 로딩 필드는 건드릴 수 없고, 이미 읽어 온 값만 쓴다.
+ */
+@Component
+@RequestScope
+public class AuthenticatedUserHolder {
+    private Users user;
+
+    public void set(Users user) {
+        this.user = user;
+    }
+
+    public Users get() {
+        return user;
+    }
+}

--- a/src/main/java/com/dearjolly/server/global/config/ErrorExampleCustomizer.java
+++ b/src/main/java/com/dearjolly/server/global/config/ErrorExampleCustomizer.java
@@ -1,0 +1,95 @@
+package com.dearjolly.server.global.config;
+
+import com.dearjolly.server.global.exception.response.ErrorCode;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+/**
+ * 실패 응답 예시를 각 응답이 실제로 내려주는 에러 코드로 바꾼다.
+ * <p>
+ * ErrorResponse 의 필드 예시는 하나뿐이라, 손대지 않으면 404 응답에도 400 · COMMON_001 예시가 붙는다.
+ * 응답 설명에 적어 둔 {@code `CODE`} 를 읽어 ErrorCode 에서 실제 상태·문구를 가져온다.
+ */
+@Component
+public class ErrorExampleCustomizer implements OperationCustomizer {
+    private static final Pattern ERROR_CODE = Pattern.compile("`([A-Z]+_\\d+)`");
+
+    private static final Map<String, ErrorCode> BY_CODE = new LinkedHashMap<>();
+
+    static {
+        for (ErrorCode errorCode : ErrorCode.values()) {
+            BY_CODE.put(errorCode.getCode(), errorCode);
+        }
+    }
+
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        if (operation.getResponses() == null) {
+            return operation;
+        }
+        operation.getResponses().forEach(this::applyExamples);
+        return operation;
+    }
+
+    private void applyExamples(String statusCode, ApiResponse response) {
+        Content content = response.getContent();
+        if (content == null || content.isEmpty()) {
+            return;
+        }
+        List<ErrorCode> errorCodes = errorCodesOf(statusCode, response.getDescription());
+        if (errorCodes.isEmpty()) {
+            return;
+        }
+        content.values().forEach(mediaType -> setExamples(mediaType, errorCodes));
+    }
+
+    // 설명에 적힌 코드 중 이 응답의 상태 코드와 실제로 맞는 것만 쓴다.
+    // 어긋난 코드가 예시로 나가면 문서가 거짓말을 하게 된다.
+    private List<ErrorCode> errorCodesOf(String statusCode, String description) {
+        if (description == null) {
+            return List.of();
+        }
+        List<ErrorCode> found = new ArrayList<>();
+        Matcher matcher = ERROR_CODE.matcher(description);
+        while (matcher.find()) {
+            ErrorCode errorCode = BY_CODE.get(matcher.group(1));
+            if (errorCode != null && String.valueOf(errorCode.getHttpStatus().value()).equals(statusCode)) {
+                found.add(errorCode);
+            }
+        }
+        return found;
+    }
+
+    // 코드가 여럿이면 Swagger 가 드롭다운으로 골라 보여준다.
+    private void setExamples(MediaType mediaType, List<ErrorCode> errorCodes) {
+        if (errorCodes.size() == 1) {
+            mediaType.setExample(bodyOf(errorCodes.getFirst()));
+            return;
+        }
+        for (ErrorCode errorCode : errorCodes) {
+            mediaType.addExamples(errorCode.getCode(), new Example()
+                    .summary(errorCode.getCode() + " — " + errorCode.getMessage())
+                    .value(bodyOf(errorCode)));
+        }
+    }
+
+    private Map<String, Object> bodyOf(ErrorCode errorCode) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", errorCode.getHttpStatus().value());
+        body.put("code", errorCode.getCode());
+        body.put("message", errorCode.getMessage());
+        return body;
+    }
+}

--- a/src/main/java/com/dearjolly/server/global/config/OpenApiConfig.java
+++ b/src/main/java/com/dearjolly/server/global/config/OpenApiConfig.java
@@ -6,12 +6,14 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springdoc.core.utils.SpringDocUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class OpenApiConfig {
     public static final String BEARER_SCHEME = "bearerAuth";
 
@@ -45,6 +47,10 @@ public class OpenApiConfig {
         // springdoc 이 평범한 Long 파라미터로 보고 userId 를 쿼리 파라미터로 문서에 노출한다.
         SpringDocUtils.getConfig().addAnnotationsToIgnore(LoginUser.class);
     }
+
+    // Swagger UI 는 그룹 문서를 띄운다. 그룹에는 전역 OperationCustomizer 가 적용되지 않으므로
+    // 여기서 직접 붙여야 실패 응답 예시가 그룹 문서에도 실린다.
+    private final ErrorExampleCustomizer errorExampleCustomizer;
 
     @Bean
     public OpenAPI openAPI() {
@@ -92,6 +98,7 @@ public class OpenApiConfig {
                 .group(name)
                 .displayName(displayName)
                 .pathsToMatch(paths)
+                .addOperationCustomizer(errorExampleCustomizer)
                 .build();
     }
 

--- a/src/main/java/com/dearjolly/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/dearjolly/server/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.dearjolly.server.global.config;
 import com.dearjolly.server.domain.user.repository.UserRepository;
 import com.dearjolly.server.global.auth.jwt.JwtAuthenticationFilter;
 import com.dearjolly.server.global.auth.jwt.JwtProvider;
+import com.dearjolly.server.global.auth.principal.AuthenticatedUserHolder;
 import com.dearjolly.server.global.exception.response.ErrorCode;
 import com.dearjolly.server.global.exception.response.ErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -53,6 +54,7 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
+    private final AuthenticatedUserHolder authenticatedUserHolder;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -71,7 +73,9 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtProvider, userRepository, objectMapper, JWT_FILTER_SKIP_PATHS),
+                        new JwtAuthenticationFilter(
+                                jwtProvider, userRepository, authenticatedUserHolder,
+                                objectMapper, JWT_FILTER_SKIP_PATHS),
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .exceptionHandling(handling -> handling

--- a/src/main/java/com/dearjolly/server/global/seed/UserSeedWriter.java
+++ b/src/main/java/com/dearjolly/server/global/seed/UserSeedWriter.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -54,9 +53,7 @@ public class UserSeedWriter {
         Users user = findOrCreateUser(properties);
         agreeAllTerms(user);
 
-        Set<String> written = user.getLetters().stream()
-                .map(Letters::getContent)
-                .collect(Collectors.toCollection(HashSet::new));
+        Set<String> written = new HashSet<>(letterRepository.findAllContentByUserId(user.getId()));
         int created = 0;
         int completed = 0;
         for (LetterSeed seed : oldestFirst(letterSeeds)) {

--- a/src/test/java/com/dearjolly/server/domain/letter/controller/LetterApiTest.java
+++ b/src/test/java/com/dearjolly/server/domain/letter/controller/LetterApiTest.java
@@ -222,6 +222,19 @@ class LetterApiTest extends ApiTestSupport {
                 .body("code", equalTo("AUTH_005"));
     }
 
+    @DisplayName("온보딩 가드가 인증 필터가 조회한 사용자를 다시 조회하지 않는다")
+    @Test
+    void onboardingGuardReusesAuthenticatedUser() {
+        // given
+        Users user = 온보딩을_마친_유저를_저장한다("kakao-reuse", "jolly");
+
+        // when
+        long 쿼리수 = 실행된_쿼리수(() -> 편지목록을_조회한다(user));
+
+        // then - 사용자 1 + 약관 1 + 편지 1
+        assertThat(쿼리수).isEqualTo(3);
+    }
+
     @DisplayName("GET /api/v1/letters : 편지가 늘어도 쿼리 수가 늘지 않는다")
     @Test
     void getLettersDoesNotIssueQueryPerLetter() {

--- a/src/test/java/com/dearjolly/server/domain/letter/controller/LetterApiTest.java
+++ b/src/test/java/com/dearjolly/server/domain/letter/controller/LetterApiTest.java
@@ -222,6 +222,33 @@ class LetterApiTest extends ApiTestSupport {
                 .body("code", equalTo("AUTH_005"));
     }
 
+    @DisplayName("GET /api/v1/letters : 편지가 늘어도 쿼리 수가 늘지 않는다")
+    @Test
+    void getLettersDoesNotIssueQueryPerLetter() {
+        // given - 목록 응답은 피드백을 쓰지 않지만, 비소유 측 @OneToOne 은 프록시가 안 돼
+        //         함께 가져오지 않으면 편지마다 조회가 한 번씩 더 나간다.
+        Users user = 온보딩을_마친_유저를_저장한다("kakao-nplus1", "jolly");
+        피드백완료_편지를_저장한다(user, "The first letter.", LocalDate.of(2025, 11, 1), "n1-stamp-0");
+        long 편지_한통일_때 = 실행된_쿼리수(() -> 편지목록을_조회한다(user));
+
+        for (int i = 1; i <= 5; i++) {
+            피드백완료_편지를_저장한다(user, "Letter number " + i + ".", LocalDate.of(2025, 10, i), "n1-stamp-" + i);
+        }
+
+        // when
+        long 편지_여섯통일_때 = 실행된_쿼리수(() -> 편지목록을_조회한다(user));
+
+        // then
+        assertThat(편지_여섯통일_때).isEqualTo(편지_한통일_때);
+    }
+
+    private void 편지목록을_조회한다(Users user) {
+        given().header(HttpHeaders.AUTHORIZATION, 액세스토큰(user))
+                .when().get("/api/v1/letters")
+                .then()
+                .statusCode(HttpStatus.OK.value());
+    }
+
     @DisplayName("GET /api/v1/letters : 편지 목록 조회 API")
     @Test
     void getLetters() {

--- a/src/test/java/com/dearjolly/server/domain/user/service/WithdrawnUserPurgerTest.java
+++ b/src/test/java/com/dearjolly/server/domain/user/service/WithdrawnUserPurgerTest.java
@@ -1,0 +1,66 @@
+package com.dearjolly.server.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dearjolly.server.domain.letter.entity.Letters;
+import com.dearjolly.server.domain.user.entity.Users;
+import com.dearjolly.server.support.ApiTestSupport;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class WithdrawnUserPurgerTest extends ApiTestSupport {
+    @Autowired
+    private WithdrawnUserPurger withdrawnUserPurger;
+
+    @DisplayName("탈퇴 계정과 그 편지 · 피드백 · 약관 동의를 함께 지운다.")
+    @Test
+    void purge() {
+        // given
+        Users user = 온보딩을_마친_유저를_저장한다("kakao-purge", "jolly");
+        Letters letter = 피드백완료_편지를_저장한다(user, "A letter to purge.", LocalDate.of(2025, 11, 1), "purge-stamp");
+        피드백을_붙여_저장한다(letter, "A letter to purge.",
+                List.<String[]>of(new String[]{"A letter", "A letter"}), List.of("팁 하나"));
+
+        // when
+        withdrawnUserPurger.purge(List.of(user.getId()));
+
+        // then
+        assertThat(userRepository.findById(user.getId())).isEmpty();
+        assertThat(행수("letters")).isZero();
+        assertThat(행수("feedbacks")).isZero();
+        assertThat(행수("feedback_tips")).isZero();
+        assertThat(행수("correction_segments")).isZero();
+        assertThat(행수("terms_agreements")).isZero();
+    }
+
+    @DisplayName("계정이 늘어도 삭제 쿼리 수는 늘지 않는다.")
+    @Test
+    void purgeDoesNotIssueQueryPerUser() {
+        // given
+        Users one = 온보딩을_마친_유저를_저장한다("kakao-bulk-1", "jolly");
+        피드백완료_편지를_저장한다(one, "One.", LocalDate.of(2025, 11, 1), "bulk-stamp-1");
+        long 계정_하나일_때 = 실행된_쿼리수(() -> withdrawnUserPurger.purge(List.of(one.getId())));
+
+        List<Long> many = new ArrayList<>();
+        for (int i = 2; i <= 6; i++) {
+            Users user = 온보딩을_마친_유저를_저장한다("kakao-bulk-" + i, "jolly" + i);
+            피드백완료_편지를_저장한다(user, "Letter " + i + ".", LocalDate.of(2025, 11, i), "bulk-stamp-" + i);
+            many.add(user.getId());
+        }
+
+        // when
+        long 계정_다섯일_때 = 실행된_쿼리수(() -> withdrawnUserPurger.purge(many));
+
+        // then
+        assertThat(계정_다섯일_때).isEqualTo(계정_하나일_때);
+    }
+
+    private long 행수(String table) {
+        return ((Number) entityManager.createNativeQuery("SELECT COUNT(*) FROM " + table)
+                .getSingleResult()).longValue();
+    }
+}

--- a/src/test/java/com/dearjolly/server/global/config/OpenApiDocsTest.java
+++ b/src/test/java/com/dearjolly/server/global/config/OpenApiDocsTest.java
@@ -3,6 +3,7 @@ package com.dearjolly.server.global.config;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -52,6 +53,32 @@ class OpenApiDocsTest extends ApiTestSupport {
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .body("paths", notNullValue());
+    }
+
+    @DisplayName("GET /v3/api-docs : 실패 응답 예시가 그 응답의 실제 에러 코드로 채워진다")
+    @Test
+    void errorExamplesMatchTheirErrorCode() {
+        given()
+                .when().get("/v3/api-docs")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("paths.'/api/v1/version'.get.responses.'404'.content.'*/*'.example.code",
+                        equalTo("VERSION_002"))
+                .body("paths.'/api/v1/version'.get.responses.'404'.content.'*/*'.example.status",
+                        equalTo(404))
+                .body("paths.'/api/v1/version'.get.responses.'400'.content.'*/*'.examples",
+                        allOf(hasKey("COMMON_001"), hasKey("VERSION_001")));
+    }
+
+    @DisplayName("GET /v3/api-docs/{group} : 그룹 문서에도 실패 응답 예시가 실린다")
+    @Test
+    void errorExamplesAreAppliedToGroupedDocs() {
+        given()
+                .when().get("/v3/api-docs/version")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("paths.'/api/v1/version'.get.responses.'404'.content.'*/*'.example.code",
+                        equalTo("VERSION_002"));
     }
 
     @DisplayName("GET /v3/api-docs : @LoginUser 는 쿼리 파라미터로 노출되지 않는다")

--- a/src/test/java/com/dearjolly/server/global/seed/UserSeedWriterTest.java
+++ b/src/test/java/com/dearjolly/server/global/seed/UserSeedWriterTest.java
@@ -23,6 +23,7 @@ import com.dearjolly.server.domain.user.enums.Role;
 import com.dearjolly.server.domain.user.enums.TermsType;
 import com.dearjolly.server.domain.user.repository.TermsAgreementRepository;
 import com.dearjolly.server.domain.user.repository.UserRepository;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,6 +73,8 @@ class UserSeedWriterTest {
 
     private UserSeedWriter userSeedWriter;
 
+    private final List<String> 저장된_편지본문 = new ArrayList<>();
+
     @BeforeEach
     void setUp() {
         userSeedWriter = new UserSeedWriter(
@@ -79,7 +82,11 @@ class UserSeedWriterTest {
         );
         ReflectionTestUtils.setField(userSeedWriter, "currentTermsVersion", "1.0.0");
 
-        given(letterRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(letterRepository.save(any())).willAnswer(invocation -> {
+            저장된_편지본문.add(((Letters) invocation.getArgument(0)).getContent());
+            return invocation.getArgument(0);
+        });
+        given(letterRepository.findAllContentByUserId(anyLong())).willReturn(저장된_편지본문);
         given(termsAgreementRepository.findAllByUserIdOrderByAgreedAtDesc(anyLong())).willReturn(List.of());
         given(stampRepository.findByName(anyString())).willReturn(Optional.of(stamp()));
     }

--- a/src/test/java/com/dearjolly/server/support/ApiTestSupport.java
+++ b/src/test/java/com/dearjolly/server/support/ApiTestSupport.java
@@ -21,11 +21,14 @@ import com.dearjolly.server.global.version.entity.AppVersions;
 import com.dearjolly.server.global.version.enums.Platform;
 import com.dearjolly.server.global.version.repository.AppVersionRepository;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceContext;
 import io.restassured.RestAssured;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -64,6 +67,9 @@ public abstract class ApiTestSupport {
 
     @Autowired
     protected JwtProvider jwtProvider;
+
+    @Autowired
+    protected EntityManagerFactory entityManagerFactory;
 
     @BeforeEach
     void setUpPort() {
@@ -140,6 +146,13 @@ public abstract class ApiTestSupport {
         user.updateNickname(nickname);
         필수약관에_동의한다(user);
         return userRepository.save(user);
+    }
+
+    protected long 실행된_쿼리수(Runnable 호출) {
+        Statistics statistics = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        statistics.clear();
+        호출.run();
+        return statistics.getPrepareStatementCount();
     }
 
     protected String 관리자_액세스토큰() {

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -7,6 +7,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+    properties:
+      hibernate:
+        # 쿼리 수를 세어 N+1 을 잡아내는 테스트가 있다.
+        generate_statistics: true
   flyway:
     enabled: false
 


### PR DESCRIPTION
## 📣 Related Issue
- close #

## 📝 Key Changes

편지 목록 API 를 들여다보다가 편지 수만큼 조회가 나가는 걸 발견해서, 쿼리가 나가는 경로를 전부 훑고 정리했습니다.

### 1. 편지 목록의 N+1

편지 6통을 조회하는데 `feedbacks` 조회가 6번 나가고 있었습니다.

`Letters.feedback` 이 `@OneToOne(mappedBy = "letter", fetch = LAZY)` 인데, **비소유 측 OneToOne 은 프록시를 만들 수 없습니다.** 필드에 `null` 을 넣을지 객체를 넣을지 알려면 실제로 조회해 봐야 하기 때문입니다. 목록 응답(`LetterSummaryResponse`)은 피드백을 쓰지도 않는데 편지마다 조회가 딸려 나가고 있었습니다.

목록 쿼리의 엔티티 그래프에 `feedback` 을 넣어 조인 한 번으로 끝냈습니다. `size=50` 이었다면 51회가 나갈 뻔했습니다.

### 2. 요청마다 사용자를 두 번 조회하던 것

인증 필터가 토큰으로 사용자를 조회하고, 온보딩 가드가 같은 사용자를 또 조회하고 있었습니다. 편지 · 홈 API 전부에 붙는 비용이었습니다.

필터가 조회한 사용자를 요청 스코프(`AuthenticatedUserHolder`)에 담아 가드가 그대로 받아 쓰게 했습니다. 담기는 시점이 트랜잭션 밖이라 지연 로딩 필드는 건드릴 수 없고, 이미 읽어 온 값만 씁니다.

### 3. 시드가 편지를 엔티티로 읽던 것

시드가 "이 편지가 이미 있나" 를 보려고 편지 엔티티를 통째로 읽고 있었는데, 1번과 같은 이유로 편지마다 피드백 조회가 따라붙었습니다. 본문만 프로젝션으로 읽게 바꿨습니다.

### 4. 탈퇴 계정 정리를 벌크 삭제로

엔티티 cascade 에 맡기면 계정마다 편지 · 약관 컬렉션을 읽어 한 행씩 지웁니다. 쿼리가 `계정 수 × 편지 수` 만큼 늘어납니다. 자식부터 부모 순서로 벌크 삭제하도록 바꿔서, 계정이 몇 개든 6회로 끝납니다.

### 그 외
- Swagger 실패 응답 예시가 모든 에러에 `400 · COMMON_001` 로 나오던 문제 수정 (`ErrorResponse` 의 필드 예시 하나를 전부 공유하고 있었습니다). 응답 설명에 적힌 에러 코드를 읽어 `ErrorCode` 에서 실제 상태 · 문구를 가져옵니다
- 관리자 로그인 Swagger 설명에 "Refresh Token 은 없다" 가 남아 있어 실제 응답에 맞게 수정

## 📊 개선 결과

편지 6통 보유 계정 기준, 테이블별 조회 횟수입니다.

| 대상 | 개선 전 | 개선 후 |
| --- | :---: | :---: |
| `GET /api/v1/letters` | 10회 (`feedbacks` ×6) | **3회** |
| 기동 시 시드 | 13회 (`letters` ×6, `feedbacks` ×7) | **3회** |
| 탈퇴 계정 정리 | 계정 수 × 편지 수에 비례 | **6회 고정** |

## To Reviewers
- **쿼리 수를 세는 회귀 테스트를 붙였습니다.** Hibernate 통계로 "편지 1통일 때와 6통일 때 쿼리 수가 같은가" 를 검증합니다. 개수를 하드코딩하지 않아서 다른 변경에 취약하지 않고, 수정을 일부러 되돌려 테스트가 실제로 실패하는지도 확인했습니다.
- 벌크 삭제는 영속성 컨텍스트를 거치지 않아서, 끝나고 `clear()` 로 비웁니다. 지워진 행을 살아 있는 것으로 착각하지 않게 하려는 것입니다.
- `GET /home` · `GET /users` 는 아직 `users` 조회가 2회입니다. 서비스가 자기 데이터를 직접 로드하는 구조라서인데, 요청 스코프의 (준영속) 엔티티를 서비스까지 넘기면 쓰기 경로에서 변경이 반영되지 않는 함정이 생길 수 있어 두었습니다. 데이터량과 무관한 고정 1회라 N+1 은 아닙니다. 정리하는 게 낫다고 보시면 알려주세요.
- 테스트 165개 통과. 로컬 기동 후 API 21종(성공 · 실패 케이스 포함)을 직접 호출해 확인했습니다.